### PR TITLE
Fix substring extraction when delimiters missing

### DIFF
--- a/inc/functions/get-substring.php
+++ b/inc/functions/get-substring.php
@@ -20,10 +20,14 @@ namespace FlexLine\flexline;
 function get_string_between( $initial_string, $start, $end ) {
 	$initial_string = ' ' . $initial_string;
 	$ini            = strpos( $initial_string, $start );
-	if ( 0 === $ini ) {
+	if ( false === $ini ) {
 		return '';
 	}
-	$ini += strlen( $start );
-	$len  = strpos( $initial_string, $end, $ini ) - $ini;
+	$ini     += strlen( $start );
+	$end_pos  = strpos( $initial_string, $end, $ini );
+	if ( false === $end_pos || $end_pos < $ini ) {
+		return '';
+	}
+	$len = $end_pos - $ini;
 	return substr( $initial_string, $ini, $len );
 }


### PR DESCRIPTION
## Summary
- safely handle cases where start or end delimiters are absent in `get_string_between`

## Testing
- `php -l inc/functions/get-substring.php`
- `npm run lint-php` *(fails: vendor/bin/phpcs: not found)*
- `php -r "require 'inc/functions/get-substring.php'; echo FlexLine\\flexline\\get_string_between('startfooend','start','end') . PHP_EOL;"`
- `php -r "require 'inc/functions/get-substring.php'; echo FlexLine\\flexline\\get_string_between('fooend','start','end') === '' ? 'empty' : 'not empty';"`


------
https://chatgpt.com/codex/tasks/task_e_68957298a8ec832b997410dccec9bf33