### PR TITLE
docs: document scroller timing options

### DIFF
--- a/inc/theme-options/render-theme-docs.php
+++ b/inc/theme-options/render-theme-docs.php
@@ -179,6 +179,11 @@ function flexline_render_documentation_tab() {
                             <td>Displays prev/next arrow buttons overlaying the scroller.</td>
                         </tr>
                         <tr>
+                            <td class="pl-3">&nbsp;&mdash; Scroll transition in milliseconds</td>
+                            <td></td>
+                            <td>Controls slide animation speed (default 500; range 100–1500).</td>
+                        </tr>
+                        <tr>
                             <td class="pl-3">&nbsp;&mdash; Loop</td>
                             <td></td>
                             <td>Clones slides so scrolling never stops.</td>
@@ -187,6 +192,11 @@ function flexline_render_documentation_tab() {
                             <td class="pl-3">&nbsp;&mdash; Auto Scroll</td>
                             <td></td>
                             <td>Starts scrolling on page load (respecting the chosen interval).</td>
+                        </tr>
+                        <tr>
+                            <td class="pl-3">&nbsp;&mdash; Scroll interval in milliseconds</td>
+                            <td></td>
+                            <td>Controls auto‑scroll timing (default 4000; range 1000‑10000).</td>
                         </tr>
                         <tr>
                             <td class="pl-3">&nbsp;&mdash; Hide Scrollbar</td>


### PR DESCRIPTION
## Summary
- document scroller transition and interval settings with defaults and ranges

## Testing
- `npm run lint-php` *(fails: vendor/bin/phpcs not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a15925f580832b8da4fa591bccb3e7