### PR TITLE
docs: document hide pause button option

### DIFF
--- a/inc/theme-options/render-theme-docs.php
+++ b/inc/theme-options/render-theme-docs.php
@@ -189,6 +189,11 @@ function flexline_render_documentation_tab() {
                             <td>Starts scrolling on page load (respecting the chosen interval).</td>
                         </tr>
                         <tr>
+                            <td class="pl-3">&nbsp;&mdash; Hide Pause Button</td>
+                            <td></td>
+                            <td>Removes the pause button when auto‑scroll is active.</td>
+                        </tr>
+                        <tr>
                             <td class="pl-3">&nbsp;&mdash; Hide Scrollbar</td>
                             <td></td>
                             <td>Hides the native scrollbar for a cleaner look.</td>


### PR DESCRIPTION
## Summary
- document Hide Pause Button sub-option for Horizontal Scroller

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `npm run lint-php` *(fails: vendor/bin/phpcs not found)*
- `php -l inc/theme-options/render-theme-docs.php`


------
https://chatgpt.com/codex/tasks/task_e_68a159112184832b916e1dd1dcf1f18d