### PR TITLE
docs: describe scroller button overlay option

### DIFF
--- a/inc/theme-options/render-theme-docs.php
+++ b/inc/theme-options/render-theme-docs.php
@@ -179,6 +179,11 @@ function flexline_render_documentation_tab() {
                             <td>Displays prev/next arrow buttons overlaying the scroller.</td>
                         </tr>
                         <tr>
+                            <td class="pl-3">&nbsp;&mdash; Position Buttons Over Scroller</td>
+                            <td></td>
+                            <td>Overlays arrow buttons over the scrolling content.</td>
+                        </tr>
+                        <tr>
                             <td class="pl-3">&nbsp;&mdash; Loop</td>
                             <td></td>
                             <td>Clones slides so scrolling never stops.</td>


### PR DESCRIPTION
## Summary
- document the **Position Buttons Over Scroller** control in Horizontal Scroller options

## Testing
- `composer install` *(fails: requires GitHub token)*
- `npm run lint-php` *(fails: vendor/bin/phpcs not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1591b473c832ba92dea1b761aa1d5