### PR TITLE
Unify block documentation for attributes and styles

### DIFF
--- a/inc/theme-options/render-theme-docs.php
+++ b/inc/theme-options/render-theme-docs.php
@@ -16,6 +16,257 @@
  * @return void
  */
 function flexline_render_documentation_tab() {
+    // Unified block documentation.
+    $block_docs = [
+        'All blocks with Flexline panel' => [
+            'attributes' => [
+                [
+                    'name'        => 'Hide on Desktop / Tablet / Mobile',
+                    'description' => 'Toggles block visibility at common breakpoints—adds the appropriate <code>flexline-hide‑on‑*</code> class under the hood.',
+                ],
+            ],
+        ],
+        'core/image' => [
+            'attributes' => [
+                [
+                    'name'        => 'Enable Lazy Load',
+                    'description' => 'When true (the default), the image gets loading="lazy". Set it to false to omit the attribute so the browser loads the image immediately — ideal for hero images.',
+                ],
+                [
+                    'name'        => 'Open in Modal',
+                    'description' => 'Clicking the block opens a media‑modal (lightbox) instead of following its link.',
+                ],
+                [
+                    'name'        => 'Content Shift / Slide',
+                    'description' => 'Applies negative margins or transforms so content can nudge or slide relative to its normal flow—values are written as CSS custom properties.',
+                ],
+            ],
+        ],
+        'core/cover' => [
+            'attributes' => [
+                [
+                    'name'        => 'Enable Lazy Load',
+                    'description' => 'When true (the default), the image gets loading="lazy". Set it to false to omit the attribute so the browser loads the image immediately — ideal for hero images.',
+                ],
+            ],
+        ],
+        'core/button' => [
+            'attributes' => [
+                [
+                    'name'        => 'Open in Modal',
+                    'description' => 'Clicking the block opens a media‑modal (lightbox) instead of following its link.',
+                ],
+                [
+                    'name'        => 'Icon Type',
+                    'description' => 'Adds a small SVG icon (download arrow, play symbol, external‑link arrow, etc.) to the right of the label.',
+                ],
+                [
+                    'name'        => 'No Wrap',
+                    'description' => 'Prevents the label from breaking onto two lines.',
+                ],
+            ],
+        ],
+        'core/gallery' => [
+            'attributes' => [
+                [
+                    'name'        => 'Poster Gallery',
+                    'description' => 'Converts a tiled gallery into a film‑strip style with one large “poster” image.',
+                ],
+            ],
+        ],
+        'core/navigation' => [
+            'attributes' => [
+                [
+                    'name'        => 'Enable Scroll @ Mobile',
+                    'description' => 'Makes the nav list swipeable below <em>$mobile</em>.',
+                ],
+            ],
+        ],
+        'core/group' => [
+            'attributes' => [
+                [
+                    'name'        => 'Enable Group Link',
+                    'description' => 'Makes the entire container clickable—either self, new tab, or opens media modal depending on settings.',
+                ],
+                [
+                    'name'        => 'Content Shift / Slide',
+                    'description' => 'Applies negative margins or transforms so content can nudge or slide relative to its normal flow—values are written as CSS custom properties.',
+                ],
+            ],
+        ],
+        'core/stack' => [
+            'attributes' => [
+                [
+                    'name'        => 'Enable Group Link',
+                    'description' => 'Makes the entire container clickable—either self, new tab, or opens media modal depending on settings.',
+                ],
+                [
+                    'name'        => 'Content Shift / Slide',
+                    'description' => 'Applies negative margins or transforms so content can nudge or slide relative to its normal flow—values are written as CSS custom properties.',
+                ],
+            ],
+        ],
+        'core/row' => [
+            'attributes' => [
+                [
+                    'name'        => 'Enable Group Link',
+                    'description' => 'Makes the entire container clickable—either self, new tab, or opens media modal depending on settings.',
+                ],
+                [
+                    'name'        => 'Content Shift / Slide',
+                    'description' => 'Applies negative margins or transforms so content can nudge or slide relative to its normal flow—values are written as CSS custom properties.',
+                ],
+            ],
+        ],
+        'core/grid' => [
+            'attributes' => [
+                [
+                    'name'        => 'Enable Group Link',
+                    'description' => 'Makes the entire container clickable—either self, new tab, or opens media modal depending on settings.',
+                ],
+            ],
+        ],
+        'core/columns' => [
+            'attributes' => [
+                [
+                    'name'        => 'Horizontal Scroller',
+                    'description' => 'Turns the container into a swipeable carousel; subordinate toggles control nav, auto‑scroll, etc.',
+                ],
+                [
+                    'name'        => 'Show Arrow Nav',
+                    'description' => 'Displays prev/next arrow buttons overlaying the scroller.',
+                ],
+                [
+                    'name'        => 'Position Buttons Over Scroller',
+                    'description' => 'Overlays arrow buttons over the scrolling content.',
+                ],
+                [
+                    'name'        => 'Scroll transition in milliseconds',
+                    'description' => 'Controls slide animation speed (default 500; range 100–1500).',
+                ],
+                [
+                    'name'        => 'Loop',
+                    'description' => 'Clones slides so scrolling never stops.',
+                ],
+                [
+                    'name'        => 'Auto Scroll',
+                    'description' => 'Starts scrolling on page load (respecting the chosen interval).',
+                ],
+                [
+                    'name'        => 'Hide Pause Button',
+                    'description' => 'Removes the pause button when auto‑scroll is active.',
+                ],
+                [
+                    'name'        => 'Scroll interval in milliseconds',
+                    'description' => 'Controls auto‑scroll timing (default 4000; range 1000‑10000).',
+                ],
+                [
+                    'name'        => 'Hide Scrollbar',
+                    'description' => 'Hides the native scrollbar for a cleaner look.',
+                ],
+                [
+                    'name'        => 'Pause on Hover',
+                    'description' => 'Pauses the auto‑scroll when the user hovers over the scroller.',
+                ],
+                [
+                    'name'        => 'Button Positions / Colors',
+                    'description' => 'Control arrow placement (top/bottom, left/right/center), background, text color, border, and box‑shadow.',
+                ],
+                [
+                    'name'        => 'Stack at Tablet',
+                    'description' => 'Switches from horizontal columns to a vertical stack at medium screens.',
+                ],
+                [
+                    'name'        => 'Content Shift / Slide',
+                    'description' => 'Applies negative margins or transforms so content can nudge or slide relative to its normal flow—values are written as CSS custom properties.',
+                ],
+            ],
+        ],
+        'core/post-template' => [
+            'attributes' => [
+                [
+                    'name'        => 'Horizontal Scroller',
+                    'description' => 'Turns the container into a swipeable carousel; subordinate toggles control nav, auto‑scroll, etc.',
+                ],
+                [
+                    'name'        => 'Show Arrow Nav',
+                    'description' => 'Displays prev/next arrow buttons overlaying the scroller.',
+                ],
+                [
+                    'name'        => 'Position Buttons Over Scroller',
+                    'description' => 'Overlays arrow buttons over the scrolling content.',
+                ],
+                [
+                    'name'        => 'Scroll transition in milliseconds',
+                    'description' => 'Controls slide animation speed (default 500; range 100–1500).',
+                ],
+                [
+                    'name'        => 'Loop',
+                    'description' => 'Clones slides so scrolling never stops.',
+                ],
+                [
+                    'name'        => 'Auto Scroll',
+                    'description' => 'Starts scrolling on page load (respecting the chosen interval).',
+                ],
+                [
+                    'name'        => 'Hide Pause Button',
+                    'description' => 'Removes the pause button when auto‑scroll is active.',
+                ],
+                [
+                    'name'        => 'Scroll interval in milliseconds',
+                    'description' => 'Controls auto‑scroll timing (default 4000; range 1000‑10000).',
+                ],
+                [
+                    'name'        => 'Hide Scrollbar',
+                    'description' => 'Hides the native scrollbar for a cleaner look.',
+                ],
+                [
+                    'name'        => 'Pause on Hover',
+                    'description' => 'Pauses the auto‑scroll when the user hovers over the scroller.',
+                ],
+                [
+                    'name'        => 'Button Positions / Colors',
+                    'description' => 'Control arrow placement (top/bottom, left/right/center), background, text color, border, and box‑shadow.',
+                ],
+            ],
+        ],
+    ];
+
+    // Merge registered block styles.
+    $block_styles       = \FlexLine\flexline\flexline_get_block_styles();
+    $style_descriptions = [
+        'columns-reverse' => 'Maintains column order in the editor but flips it when the Columns block stacks on smaller screens—handy for mobile-first layouts.',
+        'card'            => 'Clean white “card” container with border-radius & light shadow. Zero internal padding so media can edge-to-edge.',
+        'card-padded'     => 'Same as Card but with theme-small padding baked in.',
+        'card-alt'        => 'Edge-to-edge images on top; inner text gets theme-small padding. Perfect for image-lead cards.',
+        'outlined'        => 'Adds a 1-px accent border & padding, no shadow. Minimalist card alternative.',
+        'shadow-light'    => 'Subtle, soft shadow for slight elevation.',
+        'shadow-dark'     => 'Deeper shadow for stronger lift; hover swaps to diffused shadow when wrapped in a Group Link.',
+        'shadow-diffused' => 'Wide, feathered shadow—great behind covers or hero quotes.',
+        'glass'           => 'Frosted-glass effect: semi-transparent base + 10 px blur + saturate.',
+        'glass-card'      => 'Glass background plus card border-radius & light shadow—ideal over photography.',
+        'no-disc'         => 'Strips bullets & left-padding for clean checklist or icon lists.',
+        'main-header-nav' => 'Opinionated spacing & weight for primary site navigation.',
+        'dark-over-light' => 'Dark text color set atop light backgrounds; pairs with transparent links.',
+        'light-over-dark' => 'Light text on dark backgrounds for hero/footers.',
+        'outline'         => 'Navigation links gain a 1 px outline & pill padding on desktop-up.',
+        'text-shadow'     => 'Applies the theme’s subtle text shadow variable for soft lift.',
+        'eyebrow'         => 'Small uppercase “eyebrow” heading with custom font/size/color.',
+        'creative'        => 'Large decorative headline style using the site’s creative font.',
+        'glass-button'    => 'Transparent glass button with blur & subtle border that intensifies on hover.',
+        'text-link'       => 'Removes button chrome so it looks like a plain text link (adds hover underline).',
+    ];
+
+    foreach ( $block_styles as $block => $styles ) {
+        foreach ( $styles as $slug => $label ) {
+            $block_docs[ $block ]['styles'][] = [
+                'slug'        => $slug,
+                'label'       => $label,
+                'description' => $style_descriptions[ $slug ] ?? '',
+            ];
+        }
+    }
+
     ?>
     <style>
         /* Layout */
@@ -107,219 +358,54 @@ function flexline_render_documentation_tab() {
                 <h2>Flexline Theme&nbsp;Documentation</h2>
                 <p>Below you’ll find a reference for the block‑level Inspector controls <em>and</em> utility classes that ship with the theme. Everything is <strong>opt‑in</strong>: nothing changes until you either (a)&nbsp;add a class in the block editor’s <em>Additional&nbsp;CSS&nbsp;Class(es)</em> field or (b)&nbsp;toggle an option inside the block’s sidebar. Use the nav on the right to jump around.</p>
             </section>
-             <!-- ✨ BLOCK OPTIONS -->
-             <section id="block-options">
-                <h3>Block Options (Flexline&nbsp;Controls)</h3>
-                <p>The following extra toggles appear in various core blocks’ sidebars. Use them for quick layout and functionality customizations.</p>
+            <!-- ✨ BLOCK OPTIONS & STYLES -->
+            <section id="block-options">
+                <h3>Block Options &amp; Style Variations</h3>
+                <p>The following custom attributes and style variations are available on various core blocks.</p>
 
                 <table class="flexline-docs-table">
                     <thead>
                         <tr>
-                            <th style="width:30%">Option / Attribute</th>
-                            <th style="width:25%">Blocks</th>
-                            <th>What it does</th>
+                            <th style="width:25%">Block Name</th>
+                            <th style="width:35%">Custom Attribute</th>
+                            <th>Style Variation</th>
                         </tr>
                     </thead>
                     <tbody>
-                        <!-- ✦ VISIBILITY -->
-                        <tr>
-                            <td><strong>Hide on Desktop / Tablet / Mobile</strong></td>
-                            <td>All blocks with Flexline panel</td>
-                            <td>Toggles block visibility at common breakpoints—adds the appropriate <code>flexline-hide‑on‑*</code> class under the hood.</td>
-                        </tr>
-                        <!-- ✦ IMAGE / COVER -->
-                        <tr>
-                            <td><strong>Enable Lazy&nbsp;Load</strong></td>
-                            <td>Image, Cover</td>
-                            <td>When true (the default), the image gets loading="lazy". Set it to false to omit the attribute (so the browser loads the image immediately — ideal for hero images).</td>
-                        </tr>
-                        <tr>
-                            <td><strong>Open in Modal</strong></td>
-                            <td>Image, Button</td>
-                            <td>Clicking the block opens a media‑modal (lightbox) instead of following its link.</td>
-                        </tr>
-                        <!-- ✦ BUTTON -->
-                        <tr>
-                            <td><strong>Icon&nbsp;Type</strong></td>
-                            <td>Button</td>
-                            <td>Adds a small SVG icon (download arrow, play symbol, external‑link arrow, etc.) to the right of the label.</td>
-                        </tr>
-                        <tr>
-                            <td><strong>No&nbsp;Wrap</strong></td>
-                            <td>Button</td>
-                            <td>Prevents the label from breaking onto two lines.</td>
-                        </tr>
-                        <!-- ✦ GALLERY -->
-                        <tr>
-                            <td><strong>Poster&nbsp;Gallery</strong></td>
-                            <td>Gallery</td>
-                            <td>Converts a tiled gallery into a film‑strip style with one large “poster” image.</td>
-                        </tr>
-                        <!-- ✦ NAVIGATION -->
-                        <tr>
-                            <td><strong>Enable Scroll&nbsp;@&nbsp;Mobile</strong></td>
-                            <td>Navigation</td>
-                            <td>Makes the nav list swipeable below <em><?= esc_html( '$mobile' ); ?></em>.</td>
-                        </tr>
-                        <!-- ✦ GROUP -->
-                        <tr>
-                            <td><strong>Enable Group Link</strong></td>
-                            <td>Group / Stack / Row / Grid</td>
-                            <td>Makes the entire container clickable—either self, new tab, or opens media modal depending on settings.</td>
-                        </tr>
-                        <!-- ✦ COLUMNS / POST TEMPLATE: SCROLLER -->
-                        <tr>
-                            <td><strong>Horizontal Scroller</strong></td>
-                            <td>Columns, Post Template</td>
-                            <td>Turns the container into a swipeable carousel; subordinate toggles control nav, auto‑scroll, etc.</td>
-                        </tr>
-                        <tr>
-                            <td class="pl-3">&nbsp;&mdash; Show Arrow Nav</td>
-                            <td></td>
-                            <td>Displays prev/next arrow buttons overlaying the scroller.</td>
-                        </tr>
-                        <tr>
-                            <td class="pl-3">&nbsp;&mdash; Position Buttons Over Scroller</td>
-                            <td></td>
-                            <td>Overlays arrow buttons over the scrolling content.</td>
-                        </tr>
-                        <tr>
-                            <td class="pl-3">&nbsp;&mdash; Scroll transition in milliseconds</td>
-                            <td></td>
-                            <td>Controls slide animation speed (default 500; range 100–1500).</td>
-                        </tr>
-                        <tr>
-                            <td class="pl-3">&nbsp;&mdash; Loop</td>
-                            <td></td>
-                            <td>Clones slides so scrolling never stops.</td>
-                        </tr>
-                        <tr>
-                            <td class="pl-3">&nbsp;&mdash; Auto Scroll</td>
-                            <td></td>
-                            <td>Starts scrolling on page load (respecting the chosen interval).</td>
-                        </tr>
-                        <tr>
-                            <td class="pl-3">&nbsp;&mdash; Hide Pause Button</td>
-                            <td></td>
-                            <td>Removes the pause button when auto‑scroll is active.</td>
-                        </tr>
-                        <tr>
-                            <td class="pl-3">&nbsp;&mdash; Scroll interval in milliseconds</td>
-                            <td></td>
-                            <td>Controls auto‑scroll timing (default 4000; range 1000‑10000).</td>
-                        </tr>
-                        <tr>
-                            <td class="pl-3">&nbsp;&mdash; Hide Scrollbar</td>
-                            <td></td>
-                            <td>Hides the native scrollbar for a cleaner look.</td>
-                        </tr>
-                        <tr>
-                            <td class="pl-3">&nbsp;&mdash; Pause on Hover</td>
-                            <td></td>
-                            <td>Pauses the auto‑scroll when the user hovers over the scroller.</td>
-                        </tr>
-                        <tr>
-                            <td class="pl-3">&nbsp;&mdash; Button Positions / Colors</td>
-                            <td></td>
-                            <td>Control arrow placement (top/bottom, left/right/center), background, text color, border, and box‑shadow.
-                            </td>
-                        </tr>
-                        <!-- ✦ COLUMNS -->
-                        <tr>
-                            <td><strong>Stack at Tablet</strong></td>
-                            <td>Columns</td>
-                            <td>Switches from horizontal columns to a vertical stack at medium screens.</td>
-                        </tr>
-                        <!-- ✦ CONTENT SHIFT -->
-                        <tr>
-                            <td><strong>Content Shift / Slide</strong></td>
-                            <td>Image, Group, Column, etc.</td>
-                            <td>Applies negative margins or transforms so content can nudge or slide relative to its normal flow—values are written as CSS custom properties.</td>
-                        </tr>
+                    <?php
+                    foreach ( $block_docs as $block => $data ) {
+                        $attributes = $data['attributes'] ?? [];
+                        $styles     = $data['styles'] ?? [];
+                        $rows       = max( count( $attributes ), count( $styles ) );
+
+                        for ( $i = 0; $i < $rows; $i++ ) {
+                            echo '<tr>';
+                            if ( 0 === $i ) {
+                                echo '<td rowspan="' . esc_attr( $rows ) . '"><code>' . esc_html( $block ) . '</code></td>';
+                            }
+
+                            echo '<td>';
+                            if ( isset( $attributes[ $i ] ) ) {
+                                echo '<strong>' . esc_html( $attributes[ $i ]['name'] ) . '</strong><br>' . wp_kses_post( $attributes[ $i ]['description'] );
+                            }
+                            echo '</td>';
+
+                            echo '<td>';
+                            if ( isset( $styles[ $i ] ) ) {
+                                echo '<code>' . esc_html( $styles[ $i ]['slug'] ) . '</code> – ' . esc_html( $styles[ $i ]['label'] );
+                                if ( ! empty( $styles[ $i ]['description'] ) ) {
+                                    echo '<br>' . esc_html( $styles[ $i ]['description'] );
+                                }
+                            }
+                            echo '</td>';
+
+                            echo '</tr>';
+                        }
+                    }
+                    ?>
                     </tbody>
                 </table>
             </section>
-
-
-            <!-- ✨ STYLE VARIATIONS -->
-            <section id="style-variations">
-    <h3>Style Variations (Block Styles)</h3>
-    <p>Select these from the block’s <strong>Styles ►</strong> menu to instantly change appearance—no custom CSS needed.</p>
-
-    <table class="flexline-docs-table">
-        <thead>
-            <tr>
-                <th style="width:22%">Block</th>
-                <th style="width:20%">Style&nbsp;Slug</th>
-                <th style="width:22%">Label in Editor</th>
-                <th>Description</th>
-            </tr>
-        </thead>
-        <tbody>
-<?php
-/* -----------------------------------------------------------------------
- * 1.  Load block style definitions
- * -------------------------------------------------------------------- */
-$block_styles = \FlexLine\flexline\flexline_get_block_styles();
-
-/* -----------------------------------------------------------------------
- * 2.  Rich descriptions keyed by same slug
- * -------------------------------------------------------------------- */
-$style_descriptions = [
-    // Columns
-    'columns-reverse'   => 'Maintains column order in the editor but flips it when the Columns block stacks on smaller screens—handy for mobile-first layouts.',
-    // Box / layout styles
-    'card'              => 'Clean white “card” container with border-radius & light shadow. Zero internal padding so media can edge-to-edge.',
-    'card-padded'       => 'Same as Card but with theme-small padding baked in.',
-    'card-alt'          => 'Edge-to-edge images on top; inner text gets theme-small padding. Perfect for image-lead cards.',
-    'outlined'          => 'Adds a 1-px accent border & padding, no shadow. Minimalist card alternative.',
-    'shadow-light'      => 'Subtle, soft shadow for slight elevation.',
-    'shadow-dark'       => 'Deeper shadow for stronger lift; hover swaps to diffused shadow when wrapped in a Group Link.',
-    'shadow-diffused'   => 'Wide, feathered shadow—great behind covers or hero quotes.',
-    'glass'             => 'Frosted-glass effect: semi-transparent base + 10 px blur + saturate.',
-    'glass-card'        => 'Glass background plus card border-radius & light shadow—ideal over photography.',
-    // Lists
-    'no-disc'           => 'Strips bullets & left-padding for clean checklist or icon lists.',
-    // Nav
-    'main-header-nav'   => 'Opinionated spacing & weight for primary site navigation.',
-    'dark-over-light'   => 'Dark text color set atop light backgrounds; pairs with transparent links.',
-    'light-over-dark'   => 'Light text on dark backgrounds for hero/footers.',
-    'outline'           => 'Navigation links gain a 1 px outline & pill padding on desktop-up.',
-    // Text styles
-    'text-shadow'       => 'Applies the theme’s subtle text shadow variable for soft lift.',
-    'eyebrow'           => 'Small uppercase “eyebrow” heading with custom font/size/color.',
-    'creative'          => 'Large decorative headline style using the site’s creative font.',
-    // Buttons
-    'glass-button'      => 'Transparent glass button with blur & subtle border that intensifies on hover.',
-    'text-link'         => 'Removes button chrome so it looks like a plain text link (adds hover underline).',
-];
-
-/* -----------------------------------------------------------------------
- * 3.  Render table rows
- * -------------------------------------------------------------------- */
-foreach ( $block_styles as $block => $styles ) {
-    $rowspan = count( $styles );
-    $first   = true;
-
-    foreach ( $styles as $slug => $label ) {
-        echo '<tr>';
-
-        // Block name only once
-        if ( $first ) {
-            echo '<td rowspan="' . esc_attr( $rowspan ) . '"><code>' . esc_html( $block ) . '</code></td>';
-            $first = false;
-        }
-
-        echo '<td><code>' . esc_html( $slug ) . '</code></td>';
-        echo '<td>' . esc_html( $label ) . '</td>';
-        echo '<td>' . esc_html( $style_descriptions[ $slug ] ?? '' ) . '</td>';
-        echo '</tr>';
-    }
-}
-?>
-        </tbody>
-    </table>
-</section>
 
 
 
@@ -460,8 +546,7 @@ foreach ( $block_styles as $block => $styles ) {
                 <h4>On this page</h4>
                 <ul>
                     <li><a href="#intro">Introduction</a></li>
-                    <li><a href="#block-options">Flexline Block Options</a></li>
-                    <li><a href="#style-variations">Style Variations</a></li>
+                    <li><a href="#block-options">Flexline Block Options &amp; Styles</a></li>
                     <li><a href="#utility-classes">Utility Classes</a>
                         <ul>
                             <li><a href="#whitespace-overflow">Whitespace &amp; Overflow</a></li>


### PR DESCRIPTION
## Summary
- add `$block_docs` array mapping blocks to custom attributes and style variations
- replace separate block option and style tables with one unified table
- update sidebar navigation to point to combined table

## Testing
- `php -l inc/theme-options/render-theme-docs.php`
- `npm run lint-php` *(fails: vendor/bin/phpcs not found; composer install requires GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_68a1c9609550832babbba322aaa8b0c5