### PR TITLE
Add sortable docs table on theme options

### DIFF
--- a/assets/js/tablesort.js
+++ b/assets/js/tablesort.js
@@ -1,0 +1,45 @@
+(function () {
+	'use strict';
+
+	const sortTable = (table, column, desc) => {
+		const tbody = table.tBodies[0];
+		const rows = Array.from(tbody.querySelectorAll('tr'));
+
+		rows.sort((a, b) => {
+			const A = a.cells[column].textContent.trim();
+			const B = b.cells[column].textContent.trim();
+			const numA = parseFloat(A);
+			const numB = parseFloat(B);
+
+			if (!isNaN(numA) && !isNaN(numB)) {
+				return desc ? numB - numA : numA - numB;
+			}
+			return desc ? B.localeCompare(A) : A.localeCompare(B);
+		});
+
+		rows.forEach((row) => {
+			tbody.appendChild(row);
+		});
+	};
+
+	const makeSortable = (table) => {
+		const headers = table.querySelectorAll('th');
+		headers.forEach((th, i) => {
+			th.addEventListener('click', () => {
+				const desc = th.classList.toggle('sort-desc');
+				headers.forEach((h) => {
+					if (h !== th) {
+						h.classList.remove('sort-desc');
+					}
+				});
+				sortTable(table, i, desc);
+			});
+		});
+	};
+
+	window.Tablesort = (table) => {
+		if (table && table.tagName === 'TABLE') {
+			makeSortable(table);
+		}
+	};
+})();

--- a/assets/js/theme-docs.js
+++ b/assets/js/theme-docs.js
@@ -1,0 +1,7 @@
+/* global Tablesort */
+document.addEventListener('DOMContentLoaded', () => {
+	const table = document.getElementById('flexline-docs-table');
+	if (table && window.Tablesort) {
+		new Tablesort(table);
+	}
+});

--- a/inc/theme-options/render-theme-docs.php
+++ b/inc/theme-options/render-theme-docs.php
@@ -112,7 +112,7 @@ function flexline_render_documentation_tab() {
                 <h3>Block Options (Flexline&nbsp;Controls)</h3>
                 <p>The following extra toggles appear in various core blocks’ sidebars. Use them for quick layout and functionality customizations.</p>
 
-                <table class="flexline-docs-table">
+                <table id="flexline-docs-table" class="flexline-docs-table">
                     <thead>
                         <tr>
                             <th style="width:30%">Option / Attribute</th>

--- a/inc/theme-options/theme-menu.php
+++ b/inc/theme-options/theme-menu.php
@@ -34,3 +34,20 @@ function flexline_enqueue_media_uploader() {
     }
 }
 add_action('admin_enqueue_scripts', __NAMESPACE__ . '\flexline_enqueue_media_uploader');
+
+/**
+ * Enqueue scripts for the theme options page.
+ *
+ * @param string $hook Current admin page hook.
+ * @return void
+ */
+function flexline_enqueue_theme_options_assets( $hook ) {
+    if ( 'appearance_page_flexline_theme_options' !== $hook ) {
+        return;
+    }
+
+    $base = get_template_directory_uri() . '/assets/js/';
+    wp_enqueue_script( 'tablesort', $base . 'tablesort.js', array(), '1.0', true );
+    wp_enqueue_script( 'flexline-theme-docs', $base . 'theme-docs.js', array( 'tablesort' ), '1.0', true );
+}
+add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\flexline_enqueue_theme_options_assets' );


### PR DESCRIPTION
## Summary
- add lightweight table sorting library and init script for theme options page
- assign unique ID to docs table and enable column sorting

## Testing
- `npx wp-scripts lint-js assets/js/tablesort.js assets/js/theme-docs.js --fix`
- `npm run lint-php` *(fails: vendor/bin/phpcs: not found)*
- `npm test` *(fails: Missing script: "test")*
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a1c9613904832bae9e9303027f680b