### PR TITLE
Refactor block docs table rows

### DIFF
--- a/inc/theme-options/render-theme-docs.php
+++ b/inc/theme-options/render-theme-docs.php
@@ -342,6 +342,15 @@ function flexline_render_documentation_tab() {
             font-weight: 600;
         }
 
+        .flexline-docs-table td.block-name {
+            background: #fdfdfd;
+            font-weight: 600;
+        }
+
+        .flexline-docs-table tbody tr:nth-child(even) td.block-name {
+            background: #f7f7f7;
+        }
+
         code {
             background: #f0f0f0;
             padding: 2px 4px;
@@ -380,9 +389,7 @@ function flexline_render_documentation_tab() {
 
                         for ( $i = 0; $i < $rows; $i++ ) {
                             echo '<tr>';
-                            if ( 0 === $i ) {
-                                echo '<td rowspan="' . esc_attr( $rows ) . '"><code>' . esc_html( $block ) . '</code></td>';
-                            }
+                            echo '<td class="block-name"><code>' . esc_html( $block ) . '</code></td>';
 
                             echo '<td>';
                             if ( isset( $attributes[ $i ] ) ) {


### PR DESCRIPTION
## Summary
- render each block/attribute/style row with its block name to avoid `rowspan`
- add styling for repeated block-name cells with alternating background

## Testing
- `php -l inc/theme-options/render-theme-docs.php`
- `node - <<'NODE' ... NODE` (simulates tablesort sort and verifies row alignment)
- `npm run lint-php` *(fails: vendor/bin/phpcs: not found)*
- `composer install` *(fails: requires GitHub token)*


------
https://chatgpt.com/codex/tasks/task_e_68a214d2b284832b884e1105a737e4c4