### PR TITLE
Present style variation labels before slugs in docs

### DIFF
--- a/inc/theme-options/render-theme-docs.php
+++ b/inc/theme-options/render-theme-docs.php
@@ -452,7 +452,7 @@ function flexline_render_documentation_tab() {
                             if ( $styles ) {
                                 echo '<ul>';
                                 foreach ( $styles as $style ) {
-                                    echo '<li><code>' . esc_html( $style['slug'] ) . '</code> – ' . esc_html( $style['label'] );
+                                    echo '<li><strong>' . esc_html( $style['label'] ) . ' -</strong> <code>' . esc_html( $style['slug'] ) . '</code>';
                                     if ( ! empty( $style['description'] ) ) {
                                         echo '<br>' . esc_html( $style['description'] );
                                     }


### PR DESCRIPTION
## Summary
- show style variation label first, then slug, in documentation table

## Testing
- `npm run lint-php` *(fails: vendor/bin/phpcs: not found)*
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `php -l inc/theme-options/render-theme-docs.php`


------
https://chatgpt.com/codex/tasks/task_e_68a213b2a4c4832b89935b9fd09c2e62