### PR TITLE
Add docs table filters for attributes and styles

### DIFF
--- a/assets/js/theme-docs.js
+++ b/assets/js/theme-docs.js
@@ -1,7 +1,46 @@
 /* global Tablesort */
 document.addEventListener('DOMContentLoaded', () => {
 	const table = document.getElementById('flexline-docs-table');
+	const attributeFilter = document.getElementById(
+		'flexline-attribute-filter'
+	);
+	const styleFilter = document.getElementById('flexline-style-filter');
+	const rows = table ? table.querySelectorAll('tbody tr') : [];
+
 	if (table && window.Tablesort) {
 		new Tablesort(table);
+	}
+
+	const filterRows = () => {
+		const selectedAttribute = attributeFilter
+			? attributeFilter.value.toLowerCase()
+			: '';
+		const selectedStyle = styleFilter
+			? styleFilter.value.toLowerCase()
+			: '';
+
+		rows.forEach((row) => {
+			const rowAttributes = (row.dataset.attributes || '').toLowerCase();
+			const rowStyles = (row.dataset.styles || '').toLowerCase();
+
+			const matchesAttribute =
+				!selectedAttribute || rowAttributes.includes(selectedAttribute);
+			const matchesStyle =
+				!selectedStyle || rowStyles.includes(selectedStyle);
+
+			if (matchesAttribute && matchesStyle) {
+				row.style.display = '';
+			} else {
+				row.style.display = 'none';
+			}
+		});
+	};
+
+	if (attributeFilter) {
+		attributeFilter.addEventListener('change', filterRows);
+	}
+
+	if (styleFilter) {
+		styleFilter.addEventListener('change', filterRows);
 	}
 });

--- a/inc/theme-options/render-theme-docs.php
+++ b/inc/theme-options/render-theme-docs.php
@@ -396,6 +396,18 @@ function flexline_render_documentation_tab() {
                 <p>The following custom attributes and style variations are available on various core blocks.</p>
 
                 <div id="flexline-docs-table-container">
+                    <style>
+                        #flexline-docs-table-container .flexline-docs-filters {
+                            display: flex;
+                            gap: 1rem;
+                            align-items: center;
+                            margin-bottom: 1rem;
+                            flex-wrap: wrap;
+                        }
+                        #flexline-docs-table-container .flexline-docs-filters label {
+                            margin-right: 0.5rem;
+                        }
+                    </style>
                     <div class="flexline-docs-filters">
                         <label for="flexline-attribute-filter">Filter by attribute</label>
                         <select id="flexline-attribute-filter">


### PR DESCRIPTION
## Summary
- add JavaScript filtering for docs table based on selected attribute and style
- style filter dropdowns above the docs table

## Testing
- `npx eslint assets/js/theme-docs.js`
- `npm run lint-php` *(fails: vendor/bin/phpcs: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a24e3f2688832b83cb089428134263