### PR TITLE
Use global Tablesort for docs table

### DIFF
--- a/assets/js/theme-docs.js
+++ b/assets/js/theme-docs.js
@@ -7,9 +7,9 @@ document.addEventListener('DOMContentLoaded', () => {
 	const styleFilter = document.getElementById('flexline-style-filter');
 	const rows = table ? table.querySelectorAll('tbody tr') : [];
 
-	if (table && window.Tablesort) {
-		new Tablesort(table);
-	}
+       if (table && window.Tablesort) {
+               Tablesort(table);
+       }
 
 	const filterRows = () => {
 		const selectedAttribute = attributeFilter


### PR DESCRIPTION
## Summary
- Fix docs table sort initialization to call global `Tablesort` function.
- Ensure docs table script references global `Tablesort` loaded before `theme-docs.js`.

## Testing
- `node - <<'NODE' ... NODE` (verified filtering still works)
- `npm run lint-js` *(fails: 37 errors, 2 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a2668f3c30832bbff9719873a0d660