### PR TITLE
feat: add docs tooltip interactions

### DIFF
--- a/assets/js/theme-docs.js
+++ b/assets/js/theme-docs.js
@@ -8,7 +8,7 @@ document.addEventListener('DOMContentLoaded', () => {
 	const rows = table ? table.querySelectorAll('tbody tr') : [];
 
        if (table && window.Tablesort) {
-               Tablesort(table);
+	       Tablesort(table);
        }
 
 	const filterRows = () => {
@@ -43,4 +43,42 @@ document.addEventListener('DOMContentLoaded', () => {
 	if (styleFilter) {
 		styleFilter.addEventListener('change', filterRows);
 	}
+
+	const tooltipPairs = [];
+	document.querySelectorAll('.flexline-info').forEach((button) => {
+		const tooltip =
+			button.nextElementSibling &&
+			button.nextElementSibling.classList.contains('flexline-tooltip')
+				? button.nextElementSibling
+				: null;
+
+		if (tooltip) {
+			tooltipPairs.push({ button, tooltip });
+		}
+	});
+
+	const closeAllTooltips = () => {
+		tooltipPairs.forEach(({ button, tooltip }) => {
+			tooltip.hidden = true;
+			button.setAttribute('aria-expanded', 'false');
+		});
+	};
+
+	tooltipPairs.forEach(({ button, tooltip }) => {
+		button.addEventListener('click', (event) => {
+			event.stopPropagation();
+			const isHidden = tooltip.hidden;
+
+			closeAllTooltips();
+
+			tooltip.hidden = !isHidden;
+			button.setAttribute('aria-expanded', isHidden ? 'true' : 'false');
+		});
+
+		tooltip.addEventListener('click', (event) => {
+			event.stopPropagation();
+		});
+	});
+
+	document.addEventListener('click', closeAllTooltips);
 });


### PR DESCRIPTION
## Summary
- add tooltip toggling to docs info buttons
- hide other tooltips and close on outside click

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint-js` *(fails: Prettier and ESLint errors in src/js)*

------
https://chatgpt.com/codex/tasks/task_e_68a26a4bba14832b87e2be3ac2d8821b