### PR TITLE
feat: style docs tooltip icon

### DIFF
--- a/assets/css/customize.css
+++ b/assets/css/customize.css
@@ -1,3 +1,8 @@
 /*
 ## Customize CSS here to avoid dealing with a build.
 */
+
+.flexline-info { color: #767676; }           /* medium gray */
+.flexline-info:hover,
+.flexline-info:focus { color: #505050; }     /* darker on interaction */
+.flexline-info svg { fill: currentColor; }


### PR DESCRIPTION
## Summary
- tint docs tooltip icon medium gray with darker hover/focus
- ensure potential SVG icons inherit currentColor

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint-php` *(fails: vendor/bin/phpcs: not found)*
- `npm run lint-js` *(fails: 37 errors, 2 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a26f2a1050832b8e594a300fe51a3d