### PR TITLE
Add breathing space to docs sidebar nav

### DIFF
--- a/inc/theme-options/render-theme-docs.php
+++ b/inc/theme-options/render-theme-docs.php
@@ -258,6 +258,7 @@ function flexline_render_documentation_tab() {
         .nav-container nav {
             position: sticky;
             top: 20px;
+            margin-top: 1rem;
             border-left: 3px solid #ececec;
             padding-left: 15px;
             font-size: 14px;


### PR DESCRIPTION
## Summary
- add top margin to theme docs sidebar navigation for better spacing

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `npm run lint-php` *(fails: vendor/bin/phpcs: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2b0530994832ba18aad371de1524c