### PR TITLE
Improve docs filter layout for theme docs

### DIFF
--- a/inc/theme-options/render-theme-docs.php
+++ b/inc/theme-options/render-theme-docs.php
@@ -388,30 +388,35 @@ function flexline_render_documentation_tab() {
                         #flexline-docs-table-container .flexline-docs-filters {
                             display: flex;
                             gap: 1rem;
-                            align-items: center;
                             margin-bottom: 1rem;
                             flex-wrap: wrap;
                         }
-                        #flexline-docs-table-container .flexline-docs-filters label {
-                            margin-right: 0.5rem;
+                        #flexline-docs-table-container .flexline-docs-filters .flexline-filter {
+                            display: flex;
+                            align-items: center;
+                            gap: 0.5rem;
                         }
                     </style>
                     <div class="flexline-docs-filters">
-                        <label for="flexline-attribute-filter">Filter by attribute</label>
-                        <select id="flexline-attribute-filter">
-                            <option value="">All</option>
-                            <?php foreach ( $unique_attribute_names as $attr_name ) : ?>
-                                <option value="<?php echo esc_attr( $attr_name ); ?>"><?php echo esc_html( $attr_name ); ?></option>
-                            <?php endforeach; ?>
-                        </select>
+                        <div class="flexline-filter">
+                            <label for="flexline-attribute-filter">Filter by attribute</label>
+                            <select id="flexline-attribute-filter">
+                                <option value="">All</option>
+                                <?php foreach ( $unique_attribute_names as $attr_name ) : ?>
+                                    <option value="<?php echo esc_attr( $attr_name ); ?>"><?php echo esc_html( $attr_name ); ?></option>
+                                <?php endforeach; ?>
+                            </select>
+                        </div>
 
-                        <label for="flexline-style-filter">Filter by style</label>
-                        <select id="flexline-style-filter">
-                            <option value="">All</option>
-                            <?php foreach ( $unique_style_slugs as $style_slug ) : ?>
-                                <option value="<?php echo esc_attr( $style_slug ); ?>"><?php echo esc_html( $style_slug ); ?></option>
-                            <?php endforeach; ?>
-                        </select>
+                        <div class="flexline-filter">
+                            <label for="flexline-style-filter">Filter by style</label>
+                            <select id="flexline-style-filter">
+                                <option value="">All</option>
+                                <?php foreach ( $unique_style_slugs as $style_slug ) : ?>
+                                    <option value="<?php echo esc_attr( $style_slug ); ?>"><?php echo esc_html( $style_slug ); ?></option>
+                                <?php endforeach; ?>
+                            </select>
+                        </div>
                     </div>
 
                     <table id="flexline-docs-table" class="flexline-docs-table">


### PR DESCRIPTION
## Summary
- wrap attribute and style filter controls in flex containers
- tweak inline styles for new `.flexline-filter` structure and remove old label spacing

## Testing
- `npm run lint-php` *(fails: vendor/bin/phpcs not found)*
- `composer install` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a2b064627c832b8defa2a0becd7287