### PR TITLE
Use font weight ranges for variable fonts

### DIFF
--- a/styles/global/flexline.json
+++ b/styles/global/flexline.json
@@ -304,7 +304,7 @@
 							"fontFamily": "'REM'",
 							"fontStretch": "normal",
 							"fontStyle": "normal",
-							"fontWeight": "100,300,500,800",
+							"fontWeight": "100 800",
 							"src": [ "file:./assets/fonts/REM/REM-VariableFont_wght.ttf" ]
 						}
 					]
@@ -319,7 +319,7 @@
 							"fontFamily": "'REM'",
 							"fontStretch": "normal",
 							"fontStyle": "normal",
-							"fontWeight": "100,300,500,800",
+							"fontWeight": "100 800",
 							"src": [ "file:./assets/fonts/REM/REM-VariableFont_wght.ttf" ]
 						}
 					]
@@ -334,7 +334,7 @@
 							"fontFamily": "'REM'",
 							"fontStretch": "normal",
 							"fontStyle": "normal",
-							"fontWeight": "100,300,500,800",
+							"fontWeight": "100 800",
 							"src": [ "file:./assets/fonts/REM/REM-VariableFont_wght.ttf" ]
 						}
 					]

--- a/styles/global/whiskey.json
+++ b/styles/global/whiskey.json
@@ -320,7 +320,7 @@
 							"fontFamily": "'Jost'",
 							"fontStretch": "normal",
 							"fontStyle": "normal",
-							"fontWeight": "200,400,600,800",
+							"fontWeight": "200 800",
 							"src": [ "file:./assets/fonts/Jost/Jost-VariableFont_wght.ttf" ]
 						}
 					]

--- a/styles/typography/flexline-fonts.json
+++ b/styles/typography/flexline-fonts.json
@@ -16,7 +16,7 @@
 							"fontFamily": "'REM'",
 							"fontStretch": "normal",
 							"fontStyle": "normal",
-							"fontWeight": "100,300,500,800",
+							"fontWeight": "100 800",
 							"src": [ "file:./assets/fonts/REM/REM-VariableFont_wght.ttf" ]
 						}
 					]
@@ -31,7 +31,7 @@
 							"fontFamily": "'REM'",
 							"fontStretch": "normal",
 							"fontStyle": "normal",
-							"fontWeight": "100,300,500,800",
+							"fontWeight": "100 800",
 							"src": [ "file:./assets/fonts/REM/REM-VariableFont_wght.ttf" ]
 						}
 					]
@@ -46,7 +46,7 @@
 							"fontFamily": "'REM'",
 							"fontStretch": "normal",
 							"fontStyle": "normal",
-							"fontWeight": "100,300,500,800",
+							"fontWeight": "100 800",
 							"src": [ "file:./assets/fonts/REM/REM-VariableFont_wght.ttf" ]
 						}
 					]

--- a/styles/typography/whiskey-fonts.json
+++ b/styles/typography/whiskey-fonts.json
@@ -34,7 +34,7 @@
 							"fontFamily": "'Jost'",
 							"fontStretch": "normal",
 							"fontStyle": "normal",
-							"fontWeight": "200,400,600,800",
+							"fontWeight": "200 800",
 							"src": [ "file:./assets/fonts/Jost/Jost-VariableFont_wght.ttf" ]
 						}
 					]

--- a/theme.json
+++ b/theme.json
@@ -302,7 +302,7 @@
 							"fontFamily": "'REM'",
 							"fontStretch": "normal",
 							"fontStyle": "normal",
-							"fontWeight": "100,300,500,800",
+							"fontWeight": "100 800",
 							"src": [ "file:./assets/fonts/REM/REM-VariableFont_wght.ttf" ]
 						}
 					]
@@ -317,7 +317,7 @@
 							"fontFamily": "'REM'",
 							"fontStretch": "normal",
 							"fontStyle": "normal",
-							"fontWeight": "100,300,500,800",
+							"fontWeight": "100 800",
 							"src": [ "file:./assets/fonts/REM/REM-VariableFont_wght.ttf" ]
 						}
 					]
@@ -332,7 +332,7 @@
 							"fontFamily": "'REM'",
 							"fontStretch": "normal",
 							"fontStyle": "normal",
-							"fontWeight": "100,300,500,800",
+							"fontWeight": "100 800",
 							"src": [ "file:./assets/fonts/REM/REM-VariableFont_wght.ttf" ]
 						}
 					]


### PR DESCRIPTION
## Summary
- replace comma-separated `fontWeight` lists with ranges in theme and style variation font definitions
- ensure variable fonts declare WordPress-compatible weight ranges

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint-js` (fails: 1337 problems)
- `npm run lint-style` (fails: 193 problems)
- `npm run lint-php` (fails: vendor/bin/phpcs: not found)
- `composer install` (fails: GitHub authentication required)

------
https://chatgpt.com/codex/tasks/task_e_68a47bca91b0832b82acf3dce6f3f71a