### PR TITLE
feat: expose full weight range for whiskey fonts

### DIFF
--- a/styles/global/whiskey.json
+++ b/styles/global/whiskey.json
@@ -319,9 +319,9 @@
 							"fontDisplay": "block",
 							"fontFamily": "'Jost'",
 							"fontStretch": "normal",
-							"fontStyle": "normal",
-							"fontWeight": "200,400,600,800",
-							"src": [ "file:./assets/fonts/Jost/Jost-VariableFont_wght.ttf" ]
+                                                        "fontStyle": "normal",
+                                                        "fontWeight": "200 900",
+                                                        "src": [ "file:./assets/fonts/Jost/Jost-VariableFont_wght.ttf" ]
 						}
 					]
 				},
@@ -334,8 +334,9 @@
 							"fontDisplay": "block",
 							"fontFamily": "'Source Sans 3', sans-serif",
 							"fontStretch": "normal",
-							"fontStyle": "normal",
-							"src": [ "file:./assets/fonts/Source_Sans_3/SourceSans3-VariableFont_wght.ttf" ]
+                                                        "fontStyle": "normal",
+                                                        "fontWeight": "200 900",
+                                                        "src": [ "file:./assets/fonts/Source_Sans_3/SourceSans3-VariableFont_wght.ttf" ]
 						}
 					]
 				},

--- a/styles/typography/whiskey-fonts.json
+++ b/styles/typography/whiskey-fonts.json
@@ -33,9 +33,9 @@
 							"fontDisplay": "block",
 							"fontFamily": "'Jost'",
 							"fontStretch": "normal",
-							"fontStyle": "normal",
-							"fontWeight": "200,400,600,800",
-							"src": [ "file:./assets/fonts/Jost/Jost-VariableFont_wght.ttf" ]
+                                                        "fontStyle": "normal",
+                                                        "fontWeight": "200 900",
+                                                        "src": [ "file:./assets/fonts/Jost/Jost-VariableFont_wght.ttf" ]
 						}
 					]
 				},
@@ -48,8 +48,9 @@
 							"fontDisplay": "block",
 							"fontFamily": "'Source Sans 3', sans-serif",
 							"fontStretch": "normal",
-							"fontStyle": "normal",
-							"src": [ "file:./assets/fonts/Source_Sans_3/SourceSans3-VariableFont_wght.ttf" ]
+                                                        "fontStyle": "normal",
+                                                        "fontWeight": "200 900",
+                                                        "src": [ "file:./assets/fonts/Source_Sans_3/SourceSans3-VariableFont_wght.ttf" ]
 						}
 					]
 				},


### PR DESCRIPTION
## Summary
- consolidate Jost fontFace definitions into a single variable font range
- expose full 200-900 weight axis for Jost and Source Sans 3 in whiskey configs

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a48db78100832b9fe0e67a1e1ed05c