### PR TITLE
chore: update variable font ranges

### DIFF
--- a/styles/global/charlie.json
+++ b/styles/global/charlie.json
@@ -320,12 +320,12 @@
 							"fontFamily": "'Quicksand'",
 							"fontStretch": "normal",
 							"fontStyle": "normal",
-							"fontWeight": "400",
-							"src": [ "file:./assets/fonts/Quicksand/Quicksand-VariableFont_wght.ttf" ]
-						}
-					]
-				},
-				{
+                                                        "fontWeight": "300 700",
+                                                        "src": [ "file:./assets/fonts/Quicksand/Quicksand-VariableFont_wght.ttf" ]
+                                                }
+                                        ]
+                                },
+                                {
 					"fontFamily": "'Source Sans 3', sans-serif",
 					"name": "Body",
 					"slug": "body",
@@ -334,12 +334,13 @@
 							"fontDisplay": "block",
 							"fontFamily": "'Source Sans 3', sans-serif",
 							"fontStretch": "normal",
-							"fontStyle": "normal",
-							"src": [ "file:./assets/fonts/Source_Sans_3/SourceSans3-VariableFont_wght.ttf" ]
-						}
-					]
-				},
-				{
+                                                        "fontStyle": "normal",
+                                                        "fontWeight": "200 900",
+                                                        "src": [ "file:./assets/fonts/Source_Sans_3/SourceSans3-VariableFont_wght.ttf" ]
+                                                }
+                                        ]
+                                },
+                                {
 					"fontFamily": "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif",
 					"name": "System Font",
 					"slug": "system-font"

--- a/styles/typography/charlie-fonts.json
+++ b/styles/typography/charlie-fonts.json
@@ -31,12 +31,12 @@
 							"fontFamily": "'Quicksand'",
 							"fontStretch": "normal",
 							"fontStyle": "normal",
-							"fontWeight": "400",
-							"src": [ "file:./assets/fonts/Quicksand/Quicksand-VariableFont_wght.ttf" ]
-						}
-					]
-				},
-				{
+                                                        "fontWeight": "300 700",
+                                                        "src": [ "file:./assets/fonts/Quicksand/Quicksand-VariableFont_wght.ttf" ]
+                                                }
+                                        ]
+                                },
+                                {
 					"fontFamily": "'Source Sans 3', sans-serif",
 					"name": "Body",
 					"slug": "body",
@@ -45,12 +45,13 @@
 							"fontDisplay": "block",
 							"fontFamily": "'Source Sans 3', sans-serif",
 							"fontStretch": "normal",
-							"fontStyle": "normal",
-							"src": [ "file:./assets/fonts/Source_Sans_3/SourceSans3-VariableFont_wght.ttf" ]
-						}
-					]
-				},
-				{
+                                                        "fontStyle": "normal",
+                                                        "fontWeight": "200 900",
+                                                        "src": [ "file:./assets/fonts/Source_Sans_3/SourceSans3-VariableFont_wght.ttf" ]
+                                                }
+                                        ]
+                                },
+                                {
 					"fontFamily": "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif",
 					"name": "System Font",
 					"slug": "system-font"


### PR DESCRIPTION
## Summary
- expand Quicksand font weight range to 300–700
- declare Source Sans 3 variable font range 200–900

## Testing
- `jq . styles/typography/charlie-fonts.json`
- `jq . styles/global/charlie.json`
- `npm test` *(fails: Missing script "test")*
- `npm run lint-js` *(fails: prettier/prettier, no-console, etc.)*
- `npm run lint-style` *(fails: stylelint errors)*
- `npm run lint-php` *(fails: vendor/bin/phpcs: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a48dbda334832bb4b194867b7e30df