### PR TITLE
feat: expand variable font weight ranges

### DIFF
--- a/styles/global/alpha.json
+++ b/styles/global/alpha.json
@@ -317,11 +317,11 @@
 					"fontFace": [
 						{
 							"fontDisplay": "block",
-							"fontFamily": "'Raleway'",
-							"fontStretch": "normal",
-							"fontStyle": "normal",
-							"fontWeight": "400",
-							"src": [ "file:./assets/fonts/Raleway/Raleway-VariableFont_wght.ttf" ]
+                                                        "fontFamily": "'Raleway'",
+                                                        "fontStretch": "normal",
+                                                        "fontStyle": "normal",
+                                                        "fontWeight": "100 900",
+                                                        "src": [ "file:./assets/fonts/Raleway/Raleway-VariableFont_wght.ttf" ]
 						}
 					]
 				},
@@ -332,11 +332,11 @@
 					"fontFace": [
 						{
 							"fontDisplay": "block",
-							"fontFamily": "'Source Sans 3', sans-serif",
-							"fontStretch": "normal",
-							"fontStyle": "normal",
-							"fontWeight": "400",
-							"src": [ "file:./assets/fonts/Source_Sans_3/SourceSans3-VariableFont_wght.ttf" ]
+                                                        "fontFamily": "'Source Sans 3', sans-serif",
+                                                        "fontStretch": "normal",
+                                                        "fontStyle": "normal",
+                                                        "fontWeight": "200 900",
+                                                        "src": [ "file:./assets/fonts/Source_Sans_3/SourceSans3-VariableFont_wght.ttf" ]
 						}
 					]
 				},

--- a/styles/typography/alpha-fonts.json
+++ b/styles/typography/alpha-fonts.json
@@ -16,7 +16,7 @@
 							"fontFamily": "'Sulphur Point'",
 							"fontStretch": "normal",
 							"fontStyle": "normal",
-							"fontWeight": "400",
+                                                        "fontWeight": "100 900",
 							"src": [ "file:./assets/fonts/Sulphur_Point/SulphurPoint-Regular.ttf" ]
 						}
 					]
@@ -28,11 +28,11 @@
 					"fontFace": [
 						{
 							"fontDisplay": "block",
-							"fontFamily": "'Raleway'",
-							"fontStretch": "normal",
-							"fontStyle": "normal",
-							"fontWeight": "400",
-							"src": [ "file:./assets/fonts/Raleway/Raleway-VariableFont_wght.ttf" ]
+                                                        "fontFamily": "'Raleway'",
+                                                        "fontStretch": "normal",
+                                                        "fontStyle": "normal",
+                                                        "fontWeight": "100 900",
+                                                        "src": [ "file:./assets/fonts/Raleway/Raleway-VariableFont_wght.ttf" ]
 						}
 					]
 				},
@@ -43,11 +43,11 @@
 					"fontFace": [
 						{
 							"fontDisplay": "block",
-							"fontFamily": "'Source Sans 3', sans-serif",
-							"fontStretch": "normal",
-							"fontStyle": "normal",
-							"fontWeight": "400",
-							"src": [ "file:./assets/fonts/Source_Sans_3/SourceSans3-VariableFont_wght.ttf" ]
+                                                        "fontFamily": "'Source Sans 3', sans-serif",
+                                                        "fontStretch": "normal",
+                                                        "fontStyle": "normal",
+                                                        "fontWeight": "200 900",
+                                                        "src": [ "file:./assets/fonts/Source_Sans_3/SourceSans3-VariableFont_wght.ttf" ]
 						}
 					]
 				},


### PR DESCRIPTION
## Summary
- allow Raleway variable font weights 100-900
- allow Source Sans 3 variable font weights 200-900

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint-php` (fails: vendor/bin/phpcs: not found)
- `npm run lint-js` (fails: lint errors)


------
https://chatgpt.com/codex/tasks/task_e_68a48dc5a394832bb168c7eac0889a40