### PR TITLE
Use variable Cabin font weight range

### DIFF
--- a/styles/global/delta.json
+++ b/styles/global/delta.json
@@ -305,7 +305,7 @@
 							"fontFamily": "'Cabin', sans-serif",
 							"fontStretch": "normal",
 							"fontStyle": "normal",
-							"fontWeight": "500",
+							"fontWeight": "400 700",
 							"src": [ "file:./assets/fonts/Cabin/Cabin-VariableFont_wdth,wght.ttf" ]
 						}
 					]

--- a/styles/typography/delta-fonts.json
+++ b/styles/typography/delta-fonts.json
@@ -19,7 +19,7 @@
 							"fontFamily": "'Cabin', sans-serif",
 							"fontStretch": "normal",
 							"fontStyle": "normal",
-							"fontWeight": "500",
+							"fontWeight": "400 700",
 							"src": [ "file:./assets/fonts/Cabin/Cabin-VariableFont_wdth,wght.ttf" ]
 						}
 					]


### PR DESCRIPTION
## Summary
- use variable weight range for Cabin font in typography and global styles

## Testing
- `npm test` (fails: Missing script: "test")
- `composer test` (fails: Command "test" is not defined.)

------
https://chatgpt.com/codex/tasks/task_e_68a48dcb9a10832bbea7e62ed536f326