### PR TITLE
refactor: map block control classes

### DIFF
--- a/src/js/blocks/controls/index.js
+++ b/src/js/blocks/controls/index.js
@@ -1,7 +1,7 @@
 import { addFilter } from '@wordpress/hooks';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { useEffect, useRef } from '@wordpress/element';
-import { getVisibilityClasses, updateBlockClasses } from '../utils';
+import { updateBlockClasses } from '../utils';
 
 import button from './button';
 import buttons from './buttons';
@@ -14,192 +14,173 @@ import columns from './columns';
 import visibility from './visibility';
 
 const handlers = {
-    'core/button': button,
-    'core/buttons': buttons,
-    'core/cover': cover,
-    'core/gallery': gallery,
-    'core/group': group,
-    'core/image': image,
-    'core/navigation': navigation,
-    'core/columns': columns,
-    'core/post-template': columns,
-    'core/column': visibility,
-    'core/spacer': visibility,
-    'core/paragraph': visibility,
-    'core/heading': visibility,
-    'core/video': visibility,
-    'core/site-logo': visibility,
-    'core/post-featured-image': visibility,
-    'core/embed': visibility,
-    'core/navigation-submenu': visibility,
-    'core/navigation-link': visibility,
-    'core/html': visibility,
-    'core/social-link': visibility,
-    'core/social-links': visibility,
+	'core/button': button,
+	'core/buttons': buttons,
+	'core/cover': cover,
+	'core/gallery': gallery,
+	'core/group': group,
+	'core/image': image,
+	'core/navigation': navigation,
+	'core/columns': columns,
+	'core/post-template': columns,
+	'core/column': visibility,
+	'core/spacer': visibility,
+	'core/paragraph': visibility,
+	'core/heading': visibility,
+	'core/video': visibility,
+	'core/site-logo': visibility,
+	'core/post-featured-image': visibility,
+	'core/embed': visibility,
+	'core/navigation-submenu': visibility,
+	'core/navigation-link': visibility,
+	'core/html': visibility,
+	'core/social-link': visibility,
+	'core/social-links': visibility,
+};
+
+// Map attributes to the classes they control.
+const classMap = {
+	hideOnMobile: { true: 'flexline-hide-on-mobile' },
+	hideOnTablet: { true: 'flexline-hide-on-tablet' },
+	hideOnDesktop: { true: 'flexline-hide-on-desktop' },
+	enableModal: { true: 'enable-modal' },
+	enableLazyLoad: { false: 'no-lazy-load' },
+	noWrap: { true: 'nowrap' },
+	enablePosterGallery: { true: 'poster-gallery' },
+	enableHorizontalScroll: { true: 'is-style-horizontal-scroll-at-mobile' },
+	stackAtTablet: { true: 'flexline-stack-at-tablet' },
+	enableGroupLink: { true: 'group-link' },
+};
+
+// Content shift related classes.
+const contentShiftMap = {
+	shiftLeft: 'flexline-content-shift-left',
+	shiftRight: 'flexline-content-shift-right',
+	shiftUp: 'flexline-content-shift-up',
+	shiftDown: 'flexline-content-shift-down',
+	slideHorizontal: 'flexline-content-slide-x',
+	slideVertical: 'flexline-content-slide-y',
+	shiftToTop: 'flexline-content-shift-above',
+	resetMobile: 'flexline-content-shift-revert-mobile',
+};
+
+const getContentShiftClasses = (attrs) => {
+	const removed = [];
+	const added = [];
+	const base = 'flexline-content-shift';
+
+	if (!attrs.useContentShift) {
+		removed.push(base, ...Object.values(contentShiftMap));
+		return { removed, added };
+	}
+
+	added.push(base);
+
+	Object.entries(contentShiftMap).forEach(([attr, cls]) => {
+		const value = attrs[attr];
+		const hasValue = [
+			'shiftLeft',
+			'shiftRight',
+			'shiftUp',
+			'shiftDown',
+			'slideHorizontal',
+			'slideVertical',
+		].includes(attr)
+			? value && value !== '0px'
+			: !!value;
+		if (hasValue) {
+			added.push(cls);
+		} else {
+			removed.push(cls);
+		}
+	});
+
+	return { removed, added };
 };
 
 const withCustomControls = createHigherOrderComponent((BlockEdit) => {
-    return (props) => {
-        const { attributes, clientId } = props;
-        const uniqueClass = `block-${clientId}`;
-        const styleElementRef = useRef(null);
+	return (props) => {
+		const { attributes, clientId } = props;
+		const uniqueClass = `block-${clientId}`;
+		const styleElementRef = useRef(null);
 
-        const handler = handlers[props.name];
-        if (handler && handler.useHooks) {
-            handler.useHooks(props);
-        }
+		const handler = handlers[props.name];
+		if (handler && handler.useHooks) {
+			handler.useHooks(props);
+		}
 
-        useEffect(() => {
-            const removedClasses = [];
-            if (!props.attributes.hideOnMobile) {
-                removedClasses.push('flexline-hide-on-mobile');
-            }
-            if (!props.attributes.hideOnTablet) {
-                removedClasses.push('flexline-hide-on-tablet');
-            }
-            if (!props.attributes.hideOnDesktop) {
-                removedClasses.push('flexline-hide-on-desktop');
-            }
-            if (!props.attributes.enableModal) {
-                removedClasses.push('enable-modal');
-            }
-            if (!props.attributes.enableLazyLoad) {
-                removedClasses.push('no-lazy-load');
-            }
-            if (!props.attributes.noWrap) {
-                removedClasses.push('nowrap');
-            }
-            if (!props.attributes.enablePosterGallery) {
-                removedClasses.push('poster-gallery');
-            }
-            if (!props.attributes.enableHorizontalScroll) {
-                removedClasses.push('is-style-horizontal-scroll-at-mobile');
-            }
-            if (!props.attributes.stackAtTablet) {
-                removedClasses.push('flexline-stack-at-tablet');
-            }
-            if (!props.attributes.enableGroupLink) {
-                removedClasses.push('group-link');
-            }
-            if (!props.attributes.useContentShift) {
-                removedClasses.push('flexline-content-shift');
-                removedClasses.push('flexline-content-shift-above');
-                removedClasses.push('flexline-content-shift-revert-mobile');
-                removedClasses.push('flexline-content-shift-left');
-                removedClasses.push('flexline-content-shift-right');
-                removedClasses.push('flexline-content-shift-up');
-                removedClasses.push('flexline-content-shift-down');
-                removedClasses.push('flexline-content-slide-x');
-                removedClasses.push('flexline-content-slide-y');
-            }
-            if (props.attributes.useContentShift) {
-                if ('0px' === props.attributes.shiftLeft) {
-                    removedClasses.push('flexline-content-shift-left');
-                }
-                if ('0px' === props.attributes.shiftRight) {
-                    removedClasses.push('flexline-content-shift-right');
-                }
-                if ('0px' === props.attributes.shiftUp) {
-                    removedClasses.push('flexline-content-shift-up');
-                }
-                if ('0px' === props.attributes.shiftDown) {
-                    removedClasses.push('flexline-content-shift-down');
-                }
-                if ('0px' === props.attributes.slideHorizontal) {
-                    removedClasses.push('flexline-content-slide-x');
-                }
-                if ('0px' === props.attributes.slideVertical) {
-                    removedClasses.push('flexline-content-slide-y');
-                }
-                if (!props.attributes.shiftToTop) {
-                    removedClasses.push('flexline-content-shift-above');
-                }
-                if (!props.attributes.resetMobile) {
-                    removedClasses.push('flexline-content-shift-revert-mobile');
-                }
-            }
+		useEffect(() => {
+			const removedClasses = [];
+			const newClasses = [];
 
-            let newClasses = getVisibilityClasses(props.attributes);
-            if (props.attributes.useContentShift) {
-                newClasses += ' flexline-content-shift';
-                if ('0px' !== props.attributes.shiftLeft) {
-                    newClasses += ' flexline-content-shift-left';
-                }
-                if ('0px' !== props.attributes.shiftRight) {
-                    newClasses += ' flexline-content-shift-right';
-                }
-                if ('0px' !== props.attributes.shiftUp) {
-                    newClasses += ' flexline-content-shift-up';
-                }
-                if ('0px' !== props.attributes.shiftDown) {
-                    newClasses += ' flexline-content-shift-down';
-                }
-                if ('0px' !== props.attributes.slideHorizontal) {
-                    newClasses += ' flexline-content-slide-x';
-                }
-                if ('0px' !== props.attributes.slideVertical) {
-                    newClasses += ' flexline-content-slide-y';
-                }
-                if (props.attributes.shiftToTop) {
-                    newClasses += ' flexline-content-shift-above';
-                }
-                if (props.attributes.resetMobile) {
-                    newClasses += ' flexline-content-shift-revert-mobile';
-                }
-            }
+			Object.entries(classMap).forEach(([attr, conditions]) => {
+				Object.entries(conditions).forEach(([expected, cls]) => {
+					const expectedBool = expected === 'true';
+					const classList = Array.isArray(cls) ? cls : [cls];
+					if (props.attributes[attr] === expectedBool) {
+						newClasses.push(...classList);
+					} else {
+						removedClasses.push(...classList);
+					}
+				});
+			});
 
-            if (handler && handler.getClasses) {
-                const blockClasses = handler.getClasses(props.attributes);
-                if (blockClasses?.removed) {
-                    removedClasses.push(...blockClasses.removed);
-                }
-                if (blockClasses?.added) {
-                    newClasses += blockClasses.added;
-                }
-            }
+			const contentShift = getContentShiftClasses(props.attributes);
+			removedClasses.push(...contentShift.removed);
+			newClasses.push(...contentShift.added);
 
-            const combinedClasses = updateBlockClasses(
-                props.attributes.className || '',
-                newClasses,
-                removedClasses
-            );
+			if (handler && handler.getClasses) {
+				const blockClasses = handler.getClasses(props.attributes);
+				if (blockClasses?.removed) {
+					removedClasses.push(...blockClasses.removed);
+				}
+				if (blockClasses?.added) {
+					newClasses.push(...blockClasses.added.trim().split(/\s+/));
+				}
+			}
 
-            if (attributes.className !== combinedClasses) {
-                props.setAttributes({ className: combinedClasses });
-            }
+			const combinedClasses = updateBlockClasses(
+				props.attributes.className || '',
+				newClasses.join(' '),
+				removedClasses
+			);
 
-            if (!props.wrapperProps) {
-                props.wrapperProps = {};
-            }
+			if (attributes.className !== combinedClasses) {
+				props.setAttributes({ className: combinedClasses });
+			}
 
-            if (props.attributes.useContentShift) {
-                let shiftLeft = '0';
-                let shiftRight = '0';
-                let shiftUp = '0';
-                let shiftDown = '0';
-                let slideX = '0';
-                let slideY = '0';
+			if (!props.wrapperProps) {
+				props.wrapperProps = {};
+			}
 
-                if (attributes.shiftLeft) {
-                    shiftLeft = '-' + attributes.shiftLeft;
-                }
-                if (attributes.shiftRight) {
-                    shiftRight = '-' + attributes.shiftRight;
-                }
-                if (attributes.shiftUp) {
-                    shiftUp = '-' + attributes.shiftUp;
-                }
-                if (attributes.shiftDown) {
-                    shiftDown = '-' + attributes.shiftDown;
-                }
-                if (attributes.slideHorizontal) {
-                    slideX = attributes.slideHorizontal;
-                }
-                if (attributes.slideVertical) {
-                    slideY = attributes.slideVertical;
-                }
+			if (props.attributes.useContentShift) {
+				let shiftLeft = '0';
+				let shiftRight = '0';
+				let shiftUp = '0';
+				let shiftDown = '0';
+				let slideX = '0';
+				let slideY = '0';
 
-                const styles = `
+				if (attributes.shiftLeft) {
+					shiftLeft = '-' + attributes.shiftLeft;
+				}
+				if (attributes.shiftRight) {
+					shiftRight = '-' + attributes.shiftRight;
+				}
+				if (attributes.shiftUp) {
+					shiftUp = '-' + attributes.shiftUp;
+				}
+				if (attributes.shiftDown) {
+					shiftDown = '-' + attributes.shiftDown;
+				}
+				if (attributes.slideHorizontal) {
+					slideX = attributes.slideHorizontal;
+				}
+				if (attributes.slideVertical) {
+					slideY = attributes.slideVertical;
+				}
+
+				const styles = `
                   #${uniqueClass} {
                         --flexline-shift-left: ${shiftLeft};
                         --flexline-shift-right: ${shiftRight};
@@ -210,34 +191,42 @@ const withCustomControls = createHigherOrderComponent((BlockEdit) => {
                   }
                 `;
 
-                if (!styleElementRef.current) {
-                    styleElementRef.current = document.createElement('style');
-                    styleElementRef.current.setAttribute('type', 'text/css');
-                    document.head.appendChild(styleElementRef.current);
-                }
+				if (!styleElementRef.current) {
+					styleElementRef.current = document.createElement('style');
+					styleElementRef.current.setAttribute('type', 'text/css');
+					document.head.appendChild(styleElementRef.current);
+				}
 
-                styleElementRef.current.textContent = styles;
-            } else if (styleElementRef.current) {
-                styleElementRef.current.parentNode.removeChild(styleElementRef.current);
-                styleElementRef.current = null;
-            }
+				styleElementRef.current.textContent = styles;
+			} else if (styleElementRef.current) {
+				styleElementRef.current.parentNode.removeChild(
+					styleElementRef.current
+				);
+				styleElementRef.current = null;
+			}
 
-            return () => {
-                if (styleElementRef.current) {
-                    styleElementRef.current.parentNode.removeChild(styleElementRef.current);
-                    styleElementRef.current = null;
-                }
-            };
-        }, [attributes, attributes.className, props.name, uniqueClass]);
+			return () => {
+				if (styleElementRef.current) {
+					styleElementRef.current.parentNode.removeChild(
+						styleElementRef.current
+					);
+					styleElementRef.current = null;
+				}
+			};
+		}, [attributes, attributes.className, handler, props, uniqueClass]);
 
-        if (handler && handler.controls) {
-            return handler.controls(BlockEdit, props);
-        }
+		if (handler && handler.controls) {
+			return handler.controls(BlockEdit, props);
+		}
 
-        return <BlockEdit {...props} />;
-    };
+		return <BlockEdit {...props} />;
+	};
 }, 'withCustomControls');
 
-addFilter('editor.BlockEdit', 'flexline/with-custom-controls', withCustomControls);
+addFilter(
+	'editor.BlockEdit',
+	'flexline/with-custom-controls',
+	withCustomControls
+);
 
 export default handlers;


### PR DESCRIPTION
## Summary
- map block attributes to their CSS classes
- centralize content shift class logic in a helper
- replace long `if` chains with iteration over class maps

## Testing
- `npm run lint-js` *(fails: 1131 errors)*
- `npx eslint src/js/blocks/controls/index.js`


------
https://chatgpt.com/codex/tasks/task_e_68a4e10375d4832b86aa1d3ee1269f2b