### PR TITLE
chore: add lint and husky setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,8 +32,9 @@ npm-debug.log*
 # Laravel Mix files
 mix-manifest.json
 
-# Husky linting files
-.husky/
+# Husky hooks
+# Keep Husky configuration files tracked
+# (Ignore any internal Husky data via nested gitignore if needed)
 
 # Yarn
 yarn-error.log

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+npx lint-staged

--- a/package.json
+++ b/package.json
@@ -9,13 +9,15 @@
     "watch": "npm run development -- --watch",
     "prod": "npm run production",
     "production": "mix --production",
+    "lint": "npm run lint-js && npm run lint-style && npm run lint-php",
     "lint-staged": "lint-staged",
     "lint-php": "vendor/bin/phpcs --standard=WordPress inc",
     "fix-php": "vendor/bin/phpcbf --standard=WordPress inc",
     "lint-js": "wp-scripts lint-js src/js",
     "lint-style": "wp-scripts lint-style src/scss",
     "ci-lint-js": "wp-scripts lint-js src/js --max-warnings=0 .",
-    "ci-lint-style": "wp-scripts lint-style src/scss --max-warnings=0"
+    "ci-lint-style": "wp-scripts lint-style src/scss --max-warnings=0",
+    "prepare": "husky"
   },
   "keywords": [],
   "author": "Joel Schlotterer",
@@ -46,11 +48,6 @@
     "*.php": "vendor/bin/phpcbf --standard=WordPress",
     "*.js": "wp-scripts lint-js",
     "*.scss": "wp-scripts lint-style"
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
-    }
   },
   "browserslist": [
     "> 1%",


### PR DESCRIPTION
## Summary
- add combined lint and prepare scripts for theme
- move husky hook to tracked `.husky` folder
- stop ignoring husky config in `.gitignore`

## Testing
- `npm run lint-js` *(fails: React Hook useEffect has a missing dependency: 'setAttributes', etc.)*
- `npm run lint-style` *(fails: Unexpected unknown at-rule "@include", etc.)*
- `npm run lint` *(fails: Unexpected console statement, 'getCurrentTemplate' is assigned a value but never used, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68a53ca5f6d8832b8f26f7ce4f779f00