### PR TITLE
docs: add utilities plugin info

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,3 +97,13 @@ If you wish to manually lint your files prior to committing, you can use the fol
   ```
 
 These commands provide a way to proactively check and fix your code, helping you avoid surprises during the commit process.
+
+## FlexLine Utilities Plugin
+
+The optional **FlexLine Utilities Plugin** adds helpful shortcodes and tools that extend the theme. After installing the plugin you can use utilities such as:
+
+- `[flexline_year]` – output the current year.
+- `[flexline_site_title]` – display the site title.
+- `[flexline_loginout]` – show a login or logout link depending on the visitor.
+
+[Download the FlexLine Utilities Plugin](https://github.com/wpengine/flexline/releases/latest/download/flexline-utilities.zip) and install it like any other WordPress plugin.

--- a/readme.txt
+++ b/readme.txt
@@ -12,6 +12,9 @@ License URI: http://www.gnu.org/licenses/gpl-2.0.html
 With its clean, minimal design and powerful feature set, FlexLine enables agencies to build stylish and sophisticated WordPress websites. FlexLine is a masterpiece of design and functionality. It features a range of valuable patterns, including hero and portfolio sections, prominent call-to-action buttons, and customer testimonials. Whether you’re building a website for your business, personal brand, or creative project, FlexLine is perfect for anyone looking to launch quickly and efficiently.
 
 
+== Installation Notes ==
+
+For additional helper features, install the optional **FlexLine Utilities Plugin**. It can be downloaded from https://github.com/wpengine/flexline/releases/latest/download/flexline-utilities.zip and provides shortcodes like `[flexline_year]` for the current year or `[flexline_loginout]` to output login and logout links.
 
 == Bundled Assets and Licenses ==
 


### PR DESCRIPTION
## Summary
- document new FlexLine Utilities Plugin and its helper shortcodes
- mention plugin availability in theme readme

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a71cb897a4832b97ad9722d60ed8ba