### PR TITLE
Add FlexLine Utilities plugin callouts

### DIFF
--- a/inc/theme-options/render-theme-docs.php
+++ b/inc/theme-options/render-theme-docs.php
@@ -379,6 +379,9 @@ if ( ! function_exists( __NAMESPACE__ . '\\flexline_render_documentation_tab' ) 
                 <!-- ✨ INTRO -->
                 <section id="intro">
                     <h2>FlexLine Theme&nbsp;Documentation</h2>
+                    <p class="notice notice-info">
+                        Grab the <a href="https://github.com/schlotterer/flexline-utilities/archive/refs/heads/main.zip">FlexLine Utilities plugin</a> for extra helpers and shortcodes like <code>[flexline_theme_docs]</code>.
+                    </p>
                     <p>Below you’ll find a reference for the block‑level Inspector controls <em>and</em> utility classes that ship with the theme. Everything is <strong>opt‑in</strong>: nothing changes until you either (a)&nbsp;add a class in the block editor’s <em>Additional&nbsp;CSS&nbsp;Class(es)</em> field or (b)&nbsp;toggle an option inside the block’s sidebar. Use the nav on the right to jump around.</p>
                 </section>
                 <!-- ✨ BLOCK OPTIONS & STYLES -->

--- a/inc/theme-options/render-theme-settings.php
+++ b/inc/theme-options/render-theme-settings.php
@@ -20,7 +20,11 @@ function flexline_render_settings_tab() {
     <form method="post" action="options.php">
         <?php settings_fields( 'flexline_theme_options_group' ); ?>
         <?php do_settings_sections( 'flexline_theme_options_group' ); ?>
-        
+
+        <p class="notice notice-info">
+            Enhance the theme with extra shortcodes and utilities by installing the <a href="https://github.com/schlotterer/flexline-utilities/archive/refs/heads/main.zip">FlexLine Utilities plugin</a>.
+        </p>
+
         <h2>Menu Settings</h2>
         <hr />
         <table class="form-table">


### PR DESCRIPTION
## Summary
- Promote FlexLine Utilities plugin in documentation with link and example shortcode.
- Add matching notice on settings tab highlighting extra utilities.

## Testing
- `composer install` (failed: CONNECT tunnel failed)
- `npm test` (missing script)
- `npm run lint` (errors: Unexpected console statements and other lint failures)


------
https://chatgpt.com/codex/tasks/task_e_68a71cb604b0832b895850f58be9c70f