### PR TITLE
Add automatic image sizes attribute

### DIFF
--- a/inc/hooks/add-auto-image-sizes.php
+++ b/inc/hooks/add-auto-image-sizes.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Adds auto to sizes attribute for images.
+ *
+ * @package flexline
+ */
+
+namespace FlexLine;
+
+/**
+ * Adds auto to the sizes attribute for all images.
+ *
+ * @author Joel Schlotterer
+ *
+ * @param array $attr Attributes for the image markup.
+ *
+ * @return array Modified attributes.
+ */
+function add_auto_to_sizes_attribute( $attr ) {
+	if ( isset( $attr['sizes'] ) && 0 !== strpos( $attr['sizes'], 'auto' ) ) {
+		$attr['sizes'] = 'auto, ' . trim( $attr['sizes'] );
+	}
+
+	return $attr;
+}
+
+add_filter( 'wp_get_attachment_image_attributes', __NAMESPACE__ . '\\add_auto_to_sizes_attribute', 10, 1 );


### PR DESCRIPTION
## Summary
- prepend `auto` to `sizes` attribute for attachment images to support automatic sizing

## Testing
- `composer install` *(fails: CONNECT tunnel failed)*
- `npm run lint` *(fails: MutationObserver is not defined, 35 problems)*


------
https://chatgpt.com/codex/tasks/task_e_68a7a430062c832b874256f5fe039fb7