### PR TITLE
Use namespaced callback for documentation tab

### DIFF
--- a/inc/theme-options/theme-page.php
+++ b/inc/theme-options/theme-page.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/render-theme-docs.php';
 
 function flexline_theme_options_page() {
     // Define the tabs and their content
@@ -9,7 +10,7 @@ function flexline_theme_options_page() {
         ],
         'documentation' => [
             'title' => 'Documentation',
-            'content' => 'flexline_render_documentation_tab'
+            'content' => '\FlexLine\flexline_render_documentation_tab'
         ]
     ];
     ?>


### PR DESCRIPTION
## Summary
- use fully qualified `\FlexLine\flexline_render_documentation_tab` for the documentation tab callback
- require the documentation renderer file before building the options page

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `npm run lint-php` *(fails: vendor/bin/phpcs: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a48fe4d4832b8c2bb664443f5255