### PR TITLE
Wrap utilities notice in plugin active check

### DIFF
--- a/inc/theme-options/render-theme-docs.php
+++ b/inc/theme-options/render-theme-docs.php
@@ -631,9 +631,14 @@ if ( ! function_exists( __NAMESPACE__ . '\\flexline_render_documentation_tab' ) 
                         <li><a href="#demo-patterns">Demo Patterns</a></li>
                         
                     </ul>
-                    <p class="notice notice-info">
-                        Download the <a href="https://github.com/schlotterer/flexline-utilities/archive/refs/heads/main.zip">FlexLine Utilities plugin</a> for extra helpers and shortcodes like <code>[flexline_theme_docs]</code> to display these docs on the front end.
-                    </p>
+                    <?php
+                    if ( ! function_exists( 'is_plugin_active' ) ) {
+                        require_once ABSPATH . 'wp-admin/includes/plugin.php';
+                    }
+                    if ( ! is_plugin_active( 'flexline-utilities/flexline-utilities.php' ) || ! is_plugin_active( 'web4sl/web4sl.php' ) ) {
+                        echo '<p class="notice notice-info">Download the <a href="https://github.com/schlotterer/flexline-utilities/archive/refs/heads/main.zip">FlexLine Utilities plugin</a> for extra helpers and shortcodes like <code>[flexline_theme_docs]</code> to display these docs on the front end.</p>';
+                    }
+                    ?>
                 </nav>
             </div><!-- /.nav-container -->
         </div><!-- /.wrapper -->

--- a/inc/theme-options/render-theme-settings.php
+++ b/inc/theme-options/render-theme-settings.php
@@ -62,9 +62,14 @@ function flexline_render_settings_tab() {
                 </td>
             </tr>
         </table>
-        <p class="notice notice-info">
-            Download the <a href="https://github.com/schlotterer/flexline-utilities/archive/refs/heads/main.zip">FlexLine Utilities plugin</a> for extra helpers and shortcodes like <code>[flexline_theme_docs]</code> to display these docs on the front end.
-        </p>
+        <?php
+        if ( ! function_exists( 'is_plugin_active' ) ) {
+            require_once ABSPATH . 'wp-admin/includes/plugin.php';
+        }
+        if ( ! is_plugin_active( 'flexline-utilities/flexline-utilities.php' ) || ! is_plugin_active( 'web4sl/web4sl.php' ) ) {
+            echo '<p class="notice notice-info">Download the <a href="https://github.com/schlotterer/flexline-utilities/archive/refs/heads/main.zip">FlexLine Utilities plugin</a> for extra helpers and shortcodes like <code>[flexline_theme_docs]</code> to display these docs on the front end.</p>';
+        }
+        ?>
         <script>
             jQuery(document).ready(function($) {
                 $('#remove-fallback-image').click(function(e) {


### PR DESCRIPTION
## Summary
- Load `is_plugin_active` when needed and gate utilities notice behind plugin activation check in theme settings
- Apply same conditional notice in theme docs tab

## Testing
- `npm run lint-php` *(fails: vendor/bin/phpcs: not found)*
- `composer install` *(fails: curl error 56, CONNECT tunnel failed)*
- `php -l inc/theme-options/render-theme-settings.php`
- `php -l inc/theme-options/render-theme-docs.php`
- `php -r 'define("ABSPATH", "/tmp/"); function is_plugin_active($p){return true;} if ( ! function_exists("is_plugin_active") ) { require_once ABSPATH . "wp-admin/includes/plugin.php"; } if ( ! is_plugin_active("flexline-utilities/flexline-utilities.php") || ! is_plugin_active("web4sl/web4sl.php") ) { echo "notice"; }'`


------
https://chatgpt.com/codex/tasks/task_e_68a7ba1c2ac0832b81d35a852a310803