### PR TITLE
Move block parsing after cancel check

### DIFF
--- a/src/js/template-pattern-inserter.js
+++ b/src/js/template-pattern-inserter.js
@@ -200,8 +200,6 @@
 			return;
 		}
 
-		const newBlocks = parse(markup);
-
 		const blocksInEd = select('core/block-editor').getBlocks();
 		let action = 'replace';
 		if (!isPristine(blocksInEd)) {
@@ -213,6 +211,8 @@
 			busy = false;
 			return;
 		}
+
+		const newBlocks = parse(markup);
 
 		if (action === 'replace') {
 			const idsToRemove = blocksInEd.map((b) => b.clientId);


### PR DESCRIPTION
## Summary
- defer block parsing until after user chooses an action when switching templates

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 'Headroom' is not defined etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a860dbf504832b9136bf369d4db8b3