### PR TITLE
docs: specify param types in template pattern inserter

### DIFF
--- a/src/js/template-pattern-inserter.js
+++ b/src/js/template-pattern-inserter.js
@@ -36,7 +36,7 @@
 
 	/**
 	 * Fetch a wp_block by slug (post_name).
-	 * @param slug
+	 * @param {string} slug
 	 */
 	const fetchStarter = async (slug) => {
 		const records = await resolveSelect('core').getEntityRecords(
@@ -49,7 +49,7 @@
 
 	/**
 	 * Canvas considered empty?
-	 * @param blocks
+	 * @param {Array} blocks
 	 */
 	const isPristine = (blocks) => {
 		if (!blocks || blocks.length === 0) {
@@ -68,7 +68,7 @@
 
 	/**
 	 * Modal prompt – returns 'replace' | 'prepend' | 'cancel'
-	 * @param starterSlug
+	 * @param {string} starterSlug
 	 */
 	const promptAction = (starterSlug) =>
 		new Promise((resolve) => {


### PR DESCRIPTION
## Summary
- document parameter types for fetchStarter, isPristine, and promptAction

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: lint errors in existing files)


------
https://chatgpt.com/codex/tasks/task_e_68a860d533c0832bb66d831c954b76a4