### PR TITLE
refactor: format modal selector

### DIFF
--- a/src/js/modal.js
+++ b/src/js/modal.js
@@ -84,7 +84,9 @@ document.addEventListener('DOMContentLoaded', () => {
 		});
 
 	document
-		.querySelectorAll('.group-link-type-modal_media .flexline-group-link-anchor')
+		.querySelectorAll(
+			'.group-link-type-modal_media .flexline-group-link-anchor'
+		)
 		.forEach((block) => {
 			const mediaUrl = block.href;
 			if (!mediaUrl) {


### PR DESCRIPTION
## Summary
- format `.querySelectorAll` selector for modal links across multiple lines

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint-js` *(fails: lint errors in other JS files)*
- `npx wp-scripts lint-js src/js/modal.js`


------
https://chatgpt.com/codex/tasks/task_e_68a860c62ac0832bb018bb1e0247e624