### PR TITLE
feat: add headroom library

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "eslint-plugin-jsx-a11y": "^6.8.0",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
+    "headroom.js": "^0.12.0",
     "husky": "^9.1.7",
     "laravel-mix": "^6.0.49",
     "lint-staged": "^16.1.5",

--- a/src/js/headroom.js
+++ b/src/js/headroom.js
@@ -1,3 +1,5 @@
+import Headroom from 'headroom.js';
+
 document.addEventListener('DOMContentLoaded', function () {
 	// Grab the header element
 	const myHeader = document.querySelector('header.site-header');


### PR DESCRIPTION
## Summary
- import Headroom from `headroom.js`
- declare Headroom dependency for bundling

## Testing
- `npm test` (fails: Missing script "test")
- `npx wp-scripts lint-js src/js/headroom.js` (fails: Unable to resolve path to module 'headroom.js')

------
https://chatgpt.com/codex/tasks/task_e_68a860bd3334832bb0059c89b46ac166