### PR TITLE
chore: remove redundant return in scroller buttons

### DIFF
--- a/src/js/global.js
+++ b/src/js/global.js
@@ -295,10 +295,6 @@ function setupScrollerButtons(scroller) {
 		observeVisibility();
 	}
 
-	if (!hasNav && !showPause) {
-		return;
-	}
-
 	const controlContainer = document.createElement('div');
 	controlContainer.classList.add('horizontal-scroller-nav-buttons');
 	controlContainer.style.position = 'absolute';


### PR DESCRIPTION
## Summary
- remove duplicate return that caused linter errors in scroller buttons setup

## Testing
- `npx --no -- wp-scripts lint-js src/js/global.js` *(fails: requestAnimationFrame and other globals undefined)*
- `npm run lint-js` *(fails: existing lint errors in other files)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68a860a9293c832ba5e6d368b6791ae8