### PR TITLE
Add global variables comment for animation observers

### DIFF
--- a/src/js/global.js
+++ b/src/js/global.js
@@ -1,3 +1,5 @@
+/* global requestAnimationFrame, MutationObserver, IntersectionObserver */
+
 // Horizontal Scroll block behaviour – front‑end + block‑editor compatible
 
 // Helper ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- declare `requestAnimationFrame`, `MutationObserver`, and `IntersectionObserver` as globals in `global.js`

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint-js` (fails: multiple lint errors in existing files)


------
https://chatgpt.com/codex/tasks/task_e_68a86098c67c832b9b5d95a9f402c05e