### PR TITLE
chore: declare MutationObserver global

### DIFF
--- a/src/js/blocks/controls/columns.js
+++ b/src/js/blocks/controls/columns.js
@@ -1,3 +1,4 @@
+/* global MutationObserver */
 import { Fragment, useEffect } from '@wordpress/element';
 import { InspectorControls } from '@wordpress/block-editor';
 import {


### PR DESCRIPTION
## Summary
- silence linter by declaring MutationObserver global in columns control

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint-js` *(fails: existing lint errors in other files)*
- `npx wp-scripts lint-js src/js/blocks/controls/columns.js`

------
https://chatgpt.com/codex/tasks/task_e_68a860781618832ba9b3226270acd795