### PR TITLE
Include setAttributes in column control dependencies

### DIFF
--- a/src/js/blocks/controls/columns.js
+++ b/src/js/blocks/controls/columns.js
@@ -447,7 +447,7 @@ export const useHooks = (props) => {
 		if (enableHorizontalScroller && isStackedOnMobile) {
 			setAttributes({ isStackedOnMobile: false });
 		}
-	}, [enableHorizontalScroller, isStackedOnMobile]);
+	}, [enableHorizontalScroller, isStackedOnMobile, setAttributes]);
 
 	useEffect(() => {
 		if (name === 'core/columns') {


### PR DESCRIPTION
## Summary
- ensure column scroller effect updates when setAttributes changes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx wp-scripts lint-js src/js/blocks/controls/columns.js` *(fails: 'MutationObserver' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a860743acc832b8d831bfee324bf72