### PR TITLE
refactor: replace experimental UnitControl

### DIFF
--- a/src/js/blocks/controls/image.js
+++ b/src/js/blocks/controls/image.js
@@ -1,10 +1,6 @@
 import { Fragment } from '@wordpress/element';
 import { InspectorControls, URLInput } from '@wordpress/block-editor';
-import {
-	PanelBody,
-	ToggleControl,
-	__experimentalUnitControl as UnitControl,
-} from '@wordpress/components';
+import { PanelBody, ToggleControl, UnitControl } from '@wordpress/components';
 import { getVisibilityControls } from '../utils';
 
 export const controls = (BlockEdit, props) => (


### PR DESCRIPTION
## Summary
- use stable `UnitControl` component from `@wordpress/components` in image control

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Prettier and ESLint errors in other files)*
- `npx wp-scripts lint-js src/js/blocks/controls/image.js`


------
https://chatgpt.com/codex/tasks/task_e_68a8609310d4832ba060365c53fe2a1d