### PR TITLE
chore: use stable UnitControl component

### DIFF
--- a/src/js/blocks/controls/group.js
+++ b/src/js/blocks/controls/group.js
@@ -4,7 +4,7 @@ import {
 	PanelBody,
 	ToggleControl,
 	SelectControl,
-	__experimentalUnitControl as UnitControl,
+	UnitControl,
 } from '@wordpress/components';
 import { getVisibilityControls } from '../utils';
 


### PR DESCRIPTION
## Summary
- replace experimental UnitControl with stable component

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: multiple lint errors in repo)
- `npx wp-scripts lint-js src/js/blocks/controls/group.js`

------
https://chatgpt.com/codex/tasks/task_e_68a86091b610832b96944e79d3e4594f