### PR TITLE
Simplify button icon check for download links

### DIFF
--- a/inc/blocks/block-extensions.php
+++ b/inc/blocks/block-extensions.php
@@ -100,13 +100,13 @@ function add_classes_to_block_content( $block_content, $added_classes ) {
  */
 function flexline_block_customizations_render( $block_content, $block ) {
 
-	if ( 'core/button' === $block['blockName'] ) {
-		if ( isset( $block['attrs']['iconType'] ) && $block['attrs']['iconType'] === 'download' ) {
-			$search_string  = 'href="';
-			$replace_string = 'download href="';
-			$block_content  = str_replace( $search_string, $replace_string, $block_content );
-		}
-	}
+        if ( 'core/button' === $block['blockName'] ) {
+                if ( 'download' === $block['attrs']['iconType'] ) {
+                        $search_string  = 'href="';
+                        $replace_string = 'download href="';
+                        $block_content  = str_replace( $search_string, $replace_string, $block_content );
+                }
+        }
 
 	if ( 'core/image' === $block['blockName'] ) {
 


### PR DESCRIPTION
## Summary
- streamline download icon detection in button block by using direct comparison

## Testing
- `npm run lint-php` *(fails: vendor/bin/phpcs not found; `composer install` requires GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_68a8e6f97f2c832ba265a3ef16c390bb