### PR TITLE
Document block editor asset hook

### DIFF
--- a/inc/blocks/block-extensions.php
+++ b/inc/blocks/block-extensions.php
@@ -9,21 +9,22 @@ namespace FlexLine;
 
 use WP_HTML_Tag_Processor;
 /**
- * Enqueue block editor assets for FlexLine theme.
+ * Enqueue block editor assets for the FlexLine theme.
  *
- * @Throws Some_Exception_Class description of exception.
+ * @return void
  */
-add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\flexline_enqueue_block_editor_assets' );
 function flexline_enqueue_block_editor_assets() {
-	// Modal addons to core button and image blocks.
-	wp_enqueue_script(
-		'flexline-block-extensions',
-		get_theme_file_uri( '/assets/built/js/block-extensions.js' ),
-		array( 'wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-compose', 'wp-rich-text' ),
-		THEME_VERSION,
-		false
-	);
+        // Modal addons to core button and image blocks.
+        wp_enqueue_script(
+                'flexline-block-extensions',
+                get_theme_file_uri( '/assets/built/js/block-extensions.js' ),
+                array( 'wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-compose', 'wp-rich-text' ),
+                THEME_VERSION,
+                false
+        );
 }
+
+add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\flexline_enqueue_block_editor_assets' );
 
 function flexline_merge_inline_style( $block_content, $new_style_rules ) {
 


### PR DESCRIPTION
## Summary
- document flexline_enqueue_block_editor_assets with a dedicated docblock and return type

## Testing
- `npm run lint-php` *(fails: vendor/bin/phpcs not found)*
- `composer install` *(fails: requires GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_68a8e6f3bc40832b91f2e4e83082b429