### PR TITLE
Document flexline_merge_inline_style function

### DIFF
--- a/inc/blocks/block-extensions.php
+++ b/inc/blocks/block-extensions.php
@@ -25,6 +25,16 @@ function flexline_enqueue_block_editor_assets() {
 	);
 }
 
+/**
+ * Merge inline style rules into a block's markup.
+ *
+ * Appends additional CSS rules to the first HTML tag found in the provided
+ * block content.
+ *
+ * @param string $block_content The original block HTML.
+ * @param string $new_style_rules CSS rules to append to the existing style attribute.
+ * @return string Updated block HTML with merged inline styles.
+ */
 function flexline_merge_inline_style( $block_content, $new_style_rules ) {
 
 	// Create the processor.


### PR DESCRIPTION
## Summary
- add PHPDoc for flexline_merge_inline_style

## Testing
- `npm test` (missing script)
- `npm run lint-php` (vendor/bin/phpcs: not found)
- `composer install` (failed to download phpcs dependency)


------
https://chatgpt.com/codex/tasks/task_e_68a8e6f6c6f8832b957b9e43a79679ea