### PR TITLE
Add missing period to template pattern inserter comment

### DIFF
--- a/inc/scripts.php
+++ b/inc/scripts.php
@@ -61,8 +61,7 @@ function flexline_admin_enqueue_scripts() {
 
 	wp_enqueue_script( 'flexline-global-admin', get_template_directory_uri() . '/assets/built/js/global.js', array(), THEME_VERSION, true );
 	// wp_enqueue_script( 'flexline-slidein-admin', get_template_directory_uri() . '/assets/built/js/slidein.js', array(), THEME_VERSION, args: true );
-
-	// Template pattern inserter
+	// Template pattern inserter.
 	wp_enqueue_script(
 		'template-pattern-inserter',
 		get_stylesheet_directory_uri() . '/assets/built/js/template-pattern-inserter.js',


### PR DESCRIPTION
## Summary
- add period to the "Template pattern inserter" comment in scripts.php for coding standards

## Testing
- `vendor/bin/phpcs inc/scripts.php` *(fails: No such file or directory)*
- `phpcs inc/scripts.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8e9b37ec4832bb8896c380c9d0c95