### PR TITLE
Escape preload script link

### DIFF
--- a/inc/setup/preload-scripts.php
+++ b/inc/setup/preload-scripts.php
@@ -13,6 +13,11 @@ namespace FlexLine;
  * @author Joel Schlotterer
  */
 function preload_scripts() {
-	echo '<link rel="preload" href="' . get_template_directory_uri() . '/assets/built/js/load-early.js" as="javascript"/>';
+        printf(
+                '<link rel="%1$s" href="%2$s/assets/built/js/load-early.js" as="%3$s" />',
+                esc_attr( 'preload' ),
+                esc_url( get_template_directory_uri() ),
+                esc_attr( 'javascript' )
+        );
 }
 add_action( 'wp_head', __NAMESPACE__ . '\preload_scripts', 1 );


### PR DESCRIPTION
## Summary
- safely escape preload link attributes and href in `preload_scripts`

## Testing
- `php -l inc/setup/preload-scripts.php`
- `vendor/bin/phpcs inc/setup/preload-scripts.php` *(fails: No such file or directory)*
- `composer install` *(fails: curl error 56: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a8e9d77324832ba966f666aed22bb4