### PR TITLE
Use theme version for poster gallery helper script

### DIFF
--- a/inc/setup/baguette-box.php
+++ b/inc/setup/baguette-box.php
@@ -23,7 +23,7 @@ namespace FlexLine;
 function register_assets() {
 	wp_register_style( 'baguettebox-css', get_template_directory_uri() . '/assets/baguetteBox/baguetteBox.min.css', array(), '1.11.1' );
 	wp_register_script( 'baguettebox', get_template_directory_uri() . '/assets/baguetteBox/baguetteBox.min.js', array(), '1.11.1', true );
-	wp_register_script( 'poster-gallery-helper', get_template_directory_uri() . '/assets/js/poster-gallery-helper.js', array(), '', true );
+        wp_register_script( 'poster-gallery-helper', get_template_directory_uri() . '/assets/js/poster-gallery-helper.js', array(), THEME_VERSION, true );
 
 	/**
 	 * Filters the CSS selector of baguetteBox.js.


### PR DESCRIPTION
## Summary
- include THEME_VERSION when registering the poster gallery helper script so it has a concrete version

## Testing
- `vendor/bin/phpcs inc/setup/baguette-box.php` *(fails: No such file or directory)*
- `composer install` *(fails: CONNECT tunnel failed, response 403; requires GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_68a8e9df6dc8832b9293a8849bf04bcd