### PR TITLE
Use strict menu visibility checks

### DIFF
--- a/inc/hooks/body-classes.php
+++ b/inc/hooks/body-classes.php
@@ -57,11 +57,11 @@ function body_classes( $classes ) {
 
 	// Add a class if header is fixed all the time.
 	$show_menu_on_scroll = get_option( 'flexline_show_menu_on_scroll_up', false );
-	if ( $show_menu_on_scroll == true ) {
+	if ( true === $show_menu_on_scroll ) {
 		$classes[] = 'headroom-in-use';
 	}
 	$show_menu_all_the_time = get_option( 'flexline_show_menu_all_the_time', false );
-	if ( $show_menu_all_the_time == true ) {
+	if ( true === $show_menu_all_the_time ) {
 		$classes[] = 'headroom--fixed-all-the-time';
 	}
 


### PR DESCRIPTION
## Summary
- use strict Yoda comparisons for menu visibility options in body class hook

## Testing
- `vendor/bin/phpcs inc/hooks/body-classes.php` *(fails: vendor/bin/phpcs: No such file or directory)*
- `composer install` *(fails: curl error 56 CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a8e9e6667c832b839184d3d1d73bd9