### PR TITLE
Normalize spacing after file header in render-theme-settings

### DIFF
--- a/inc/theme-options/render-theme-settings.php
+++ b/inc/theme-options/render-theme-settings.php
@@ -5,7 +5,6 @@
  * @package flexline
  */
 
-
 /**
  * Renders the settings tab for the flexline theme.
  *


### PR DESCRIPTION
## Summary
- ensure only one blank line follows the file header comment in `render-theme-settings.php`

## Testing
- `vendor/bin/phpcs inc/theme-options/render-theme-settings.php` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a8ea0b913c832bb50cb4981dadaf1c