### PR TITLE
Add PHPDoc and Yoda condition for logo URL helper

### DIFF
--- a/inc/functions/get-logo-url.php
+++ b/inc/functions/get-logo-url.php
@@ -7,16 +7,20 @@
 
 namespace FlexLine;
 
-// Function to get the site logo URL from the Site Editor block
+/**
+ * Retrieves the site logo URL from the Site Editor block.
+ *
+ * @return string The site logo URL or an empty string if none is found.
+ */
 function get_site_logo_from_block() {
-	// Assuming the header template part is used and its slug is 'header'
+	// Assuming the header template part is used and its slug is 'header'.
 	$header_template_part = get_block_template( 'theme_slug//header', 'wp_template_part' );
 
 	if ( $header_template_part && isset( $header_template_part->content ) ) {
 		$blocks = parse_blocks( $header_template_part->content );
 
 		foreach ( $blocks as $block ) {
-			if ( $block['blockName'] === 'core/site-logo' ) {
+			if ( 'core/site-logo' === $block['blockName'] ) {
 				if ( isset( $block['attrs']['url'] ) ) {
 					return esc_url( $block['attrs']['url'] );
 				}


### PR DESCRIPTION
## Summary
- document `get_site_logo_from_block` with a PHPDoc block
- use Yoda conditional for site logo block detection

## Testing
- `composer install` *(fails: CONNECT tunnel failed, requires GitHub token)*
- `vendor/bin/phpcs inc/functions/get-logo-url.php` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a8ea013bd8832b93952a895e4882c0