### PR TITLE
Document and sanitize theme options page

### DIFF
--- a/inc/theme-options/theme-page.php
+++ b/inc/theme-options/theme-page.php
@@ -1,8 +1,19 @@
 <?php
+/**
+ * Theme options page.
+ *
+ * @package FlexLine
+ */
+
 require_once __DIR__ . '/render-theme-docs.php';
 
+/**
+ * Displays the FlexLine theme options page.
+ *
+ * @return void
+ */
 function flexline_theme_options_page() {
-	// Define the tabs and their content
+        // Define the tabs and their content.
 	$tabs = array(
 		'settings'      => array(
 			'title'   => 'Settings',
@@ -19,17 +30,17 @@ function flexline_theme_options_page() {
 		
 		<!-- Tabs -->
 		<h2 class="nav-tab-wrapper">
-			<?php foreach ( $tabs as $tab_id => $tab ) : ?>
-				<a href="#<?php echo $tab_id; ?>" class="nav-tab" data-tab="<?php echo $tab_id; ?>" onclick="openTab(event, '<?php echo $tab_id; ?>')"><?php echo $tab['title']; ?></a>
-			<?php endforeach; ?>
-		</h2>
+                        <?php foreach ( $tabs as $tab_id => $tab ) : ?>
+                                <a href="#<?php echo esc_attr( $tab_id ); ?>" class="nav-tab" data-tab="<?php echo esc_attr( $tab_id ); ?>" onclick="openTab(event, '<?php echo esc_attr( $tab_id ); ?>')"><?php echo esc_html( $tab['title'] ); ?></a>
+                        <?php endforeach; ?>
+                </h2>
 		
 		<!-- Tab Contents -->
-		<?php foreach ( $tabs as $tab_id => $tab ) : ?>
-			<div id="<?php echo $tab_id; ?>" class="tab-content">
-				<?php call_user_func( $tab['content'] ); ?>
-			</div>
-		<?php endforeach; ?>
+                <?php foreach ( $tabs as $tab_id => $tab ) : ?>
+                        <div id="<?php echo esc_attr( $tab_id ); ?>" class="tab-content">
+                                <?php call_user_func( $tab['content'] ); ?>
+                        </div>
+                <?php endforeach; ?>
 	</div>
 	
 	<style>
@@ -77,7 +88,7 @@ function flexline_theme_options_page() {
 				uploadButton.addEventListener('click', function(e) {
 					e.preventDefault();
 					
-					// Create the media frame
+                                        // Create the media frame.
 					var imageFrame = wp.media({
 						title: 'Upload Image',
 						multiple: false,
@@ -89,20 +100,20 @@ function flexline_theme_options_page() {
 						}
 					});
 
-					// When an image is selected, run a callback
+                                        // When an image is selected, run a callback.
 					imageFrame.on('select', function() {
 						var attachment = imageFrame.state().get('selection').first().toJSON();
 						featureFallbackInput.value = attachment.url;
 						featureFallbackImage.src = attachment.url;
 					});
 
-					// Finally, open the modal
+                                        // Finally, open the modal.
 					imageFrame.open();
 				});
 			}
 		});
 	</script>
-	<?php
+<?php
 }
 
 


### PR DESCRIPTION
## Summary
- add descriptive PHPDoc headers to the theme options page
- escape tab attributes and titles for safe output
- standardize inline comment punctuation

## Testing
- `vendor/bin/phpcs inc/theme-options/theme-page.php` *(fails: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_68a8ea140fd8832bab4cbab028db74c7