### PR TITLE
chore: remove unused observer globals

### DIFF
--- a/src/js/global.js
+++ b/src/js/global.js
@@ -1,4 +1,4 @@
-/* global requestAnimationFrame, MutationObserver, IntersectionObserver */
+/* global requestAnimationFrame */
 
 // Horizontal Scroll block behaviour – front‑end + block‑editor compatible
 


### PR DESCRIPTION
## Summary
- clean up global comment in global.js by dropping MutationObserver and IntersectionObserver

## Testing
- `npx eslint src/js/global.js`


------
https://chatgpt.com/codex/tasks/task_e_68a908e30870832b9a2a190c3002cf6b