### PR TITLE
style: remove superfluous blank line

### DIFF
--- a/inc/theme-options/render-theme-settings.php
+++ b/inc/theme-options/render-theme-settings.php
@@ -5,7 +5,6 @@
  * @package flexline
  */
 
-
 /**
  * Renders the settings tab for the flexline theme.
  *


### PR DESCRIPTION
## Summary
- trim extra blank line after file-level docblock in `render-theme-settings.php`

## Testing
- `npm run lint-php` *(fails: vendor/bin/phpcs: not found; composer install 403 when fetching dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68a90d335c9c832ba889795eb1fca8d2