### PR TITLE
Load slide-in script in footer

### DIFF
--- a/inc/scripts.php
+++ b/inc/scripts.php
@@ -40,7 +40,7 @@ function flexline_enqueue_styles() {
 	}
 	wp_enqueue_script( 'flexline-load-early', get_template_directory_uri() . '/assets/built/js/load-early.js', array(), THEME_VERSION, false );
 	wp_enqueue_script( 'flexline-modal', get_template_directory_uri() . '/assets/built/js/modal.js', array(), THEME_VERSION, true );
-	wp_enqueue_script( 'flexline-slidein', get_template_directory_uri() . '/assets/built/js/slidein.js', array(), THEME_VERSION, args: true );
+        wp_enqueue_script( 'flexline-slidein', get_template_directory_uri() . '/assets/built/js/slidein.js', array(), THEME_VERSION, true );
 
 	// Customized Scripts.
 	wp_enqueue_script( 'flexline-customize', get_template_directory_uri() . '/assets/js/customize.js', array(), THEME_VERSION, true );


### PR DESCRIPTION
## Summary
- fix flexline-slidein script enqueue arguments to load in footer

## Testing
- `npm run lint-php` *(fails: vendor/bin/phpcs not found)*
- `composer install` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a90d2d5eec832b8a574f19945a5b06