### PR TITLE
Ensure proper header for theme options page

### DIFF
--- a/inc/theme-options/theme-page.php
+++ b/inc/theme-options/theme-page.php
@@ -2,7 +2,7 @@
 /**
  * Theme options page.
  *
- * @package FlexLine
+ * @package flexline
  */
 
 require_once __DIR__ . '/render-theme-docs.php';


### PR DESCRIPTION
## Summary
- fix file header package tag in theme options page

## Testing
- `npm run lint-php` *(fails: vendor/bin/phpcs: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a90d3a1318832b99a120aca1d101e6