### PR TITLE
docs: clarify image image handling comments

### DIFF
--- a/inc/functions/featured-image-fallback.php
+++ b/inc/functions/featured-image-fallback.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Return Substring from between two strings.
+ * Provides a fallback image URL when no featured image is set.
  *
  * @package flexline
  */

--- a/inc/hooks/remove-decoding-attribute.php
+++ b/inc/hooks/remove-decoding-attribute.php
@@ -1,6 +1,7 @@
 <?php
 /**
- * Adds OG tags to the head for better social sharing.
+ * Prevents WordPress from adding a decoding attribute to images,
+ * letting browsers handle decoding behavior.
  *
  * @package flexline
  */


### PR DESCRIPTION
## Summary
- fix remove-decoding-attribute header comment to describe image decoding
- explain fallback image behavior in featured-image-fallback header comment

## Testing
- `npm run lint-php` *(fails: vendor/bin/phpcs: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a916a6a5f4832bbbe0df5571eeae02