### PR TITLE
Use inline script for search menu settings

### DIFF
--- a/inc/hooks/search-menu-vars.php
+++ b/inc/hooks/search-menu-vars.php
@@ -17,15 +17,22 @@ namespace FlexLine;
  * @return void
  */
 function flexline_customize_search_menu_js_settings() {
-	?>
-	<script type="text/javascript">
-		var FlexLineCustomizerSearchMenuSettings = {
-			useMenuIconOnDesktop: <?php echo get_option( 'flexline_use_menu_icon', false ) ? 'true' : 'false'; ?>,
-			hideSearchOnTablet: <?php echo get_option( 'flexline_hide_search_tablet', false ) ? 'true' : 'false'; ?>,
-			hideSearchOnDesktop: <?php echo get_option( 'flexline_hide_search_desktop', false ) ? 'true' : 'false'; ?>,
-		};
-	</script>
-	<?php
+        if ( ! wp_script_is( 'flexline-slidein', 'enqueued' ) ) {
+                return;
+        }
+
+        $settings = array(
+                'useMenuIconOnDesktop' => (bool) get_option( 'flexline_use_menu_icon', false ),
+                'hideSearchOnTablet'   => (bool) get_option( 'flexline_hide_search_tablet', false ),
+                'hideSearchOnDesktop'  => (bool) get_option( 'flexline_hide_search_desktop', false ),
+        );
+
+        wp_add_inline_script(
+                'flexline-slidein',
+                'var FlexLineCustomizerSearchMenuSettings = ' . wp_json_encode( $settings ) . ';',
+                'before'
+        );
 }
-add_action( 'wp_head', __NAMESPACE__ . '\flexline_customize_search_menu_js_settings', 2 );
-add_action( 'enqueue_block_assets', __NAMESPACE__ . '\flexline_customize_search_menu_js_settings', 2 );
+
+add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\flexline_customize_search_menu_js_settings', 20 );
+add_action( 'enqueue_block_assets', __NAMESPACE__ . '\flexline_customize_search_menu_js_settings', 20 );


### PR DESCRIPTION
## Summary
- Replace inline `<script>` output with `wp_add_inline_script` to attach search menu options to the `flexline-slidein` handle
- Encode and sanitize option values with `wp_json_encode`

## Testing
- `php -l inc/hooks/search-menu-vars.php`
- `composer install` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a916764648832bb4c5af3a6934e26d