### PR TITLE
Remove filter disabling core block

### DIFF
--- a/inc/blocks/remove-default-blocks.php
+++ b/inc/blocks/remove-default-blocks.php
@@ -1,29 +1,11 @@
 <?php
 /**
- * Removes the core Pull Quote block.
+ * Core block customizations.
+ *
+ * Core block types remain registered; style overrides are handled via theme.json.
  *
  * @package flexline
  */
 
 namespace FlexLine;
 
-/**
- * Removes the core Pull Quote block.
- *
- * @return array
- */
-function flexline_remove_default_blocks() {
-	// Get all registered blocks.
-	$registered_blocks = \WP_Block_Type_Registry::get_instance()->get_all_registered();
-
-	// Disable default Blocks you want to remove individually.
-	unset( $registered_blocks['core/pullquote'] );
-
-	// Get keys from array.
-	$registered_blocks = array_keys( $registered_blocks );
-
-	// Merge allowed core blocks with plugins blocks.
-	return $registered_blocks;
-}
-
-add_filter( 'allowed_block_types_all', __NAMESPACE__ . '\flexline_remove_default_blocks' );


### PR DESCRIPTION
## Summary
- keep all core block types registered by removing `allowed_block_types_all` filter
- document that style overrides should be applied via `theme.json`

## Testing
- `composer install` *(fails: requires GitHub credentials)*
- `npm run lint-php` *(fails: vendor/bin/phpcs not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9164b4c98832b940d2928e68a8cf7