### PR TITLE
Use strict boolean checks for menu scripts

### DIFF
--- a/inc/scripts.php
+++ b/inc/scripts.php
@@ -34,7 +34,7 @@ function flexline_enqueue_styles() {
 	wp_enqueue_script( 'flexline-global', get_template_directory_uri() . '/assets/built/js/global.js', array(), THEME_VERSION, true );
 	$show_menu_on_scroll    = get_option( 'flexline_show_menu_on_scroll_up', false );
 	$show_menu_all_the_time = get_option( 'flexline_show_menu_all_the_time', false );
-	if ( $show_menu_on_scroll == true || $show_menu_all_the_time == true ) {
+	if ( true === $show_menu_on_scroll || true === $show_menu_all_the_time ) {
 		wp_enqueue_script( 'flexline-headroom', get_template_directory_uri() . '/assets/js/headroom.min.js', array(), THEME_VERSION, true );
 		wp_enqueue_script( 'flexline-headroom-init', get_template_directory_uri() . '/assets/built/js/headroom.js', array(), THEME_VERSION, true );
 	}


### PR DESCRIPTION
## Summary
- use strict boolean checks for menu display options when enqueueing headroom scripts

## Testing
- `npm run lint-php` *(fails: vendor/bin/phpcs not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a90d265994832bac4aeca55de8919a