### PR TITLE
Add period to CSS build comment

### DIFF
--- a/inc/blocks/block-extensions.php
+++ b/inc/blocks/block-extensions.php
@@ -236,7 +236,7 @@ function flexline_block_customizations_render( $block_content, $block ) {
 		if ( isset( $block['attrs']['slideVertical'] ) ) {
 				$slide_y = $block['attrs']['slideVertical'];
 		}
-		// Build the CSS
+               // Build the CSS.
 		$styles  = ' --flexline-shift-left: ' . esc_attr( $shift_left ) . ';';
 		$styles .= ' --flexline-shift-right: ' . esc_attr( $shift_right ) . ';';
 		$styles .= ' --flexline-shift-up: ' . esc_attr( $shift_up ) . ';';


### PR DESCRIPTION
## Summary
- fix a minor comment typo by adding a period when building CSS variables

## Testing
- `npm run lint-php` *(fails: vendor/bin/phpcs not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a90d2141a0832bb0c3426ac287c4bb