### PR TITLE
Use theme-aware asset URIs

### DIFF
--- a/inc/functions/featured-image-fallback.php
+++ b/inc/functions/featured-image-fallback.php
@@ -14,8 +14,8 @@ namespace FlexLine;
  * @return string url for image.
  */
 function feature_image_fallback() {
-	$theme_level_fallback = get_template_directory_uri() . '/assets/built/images/fallback.webp';
-	$fallback_setting_url = get_option( 'flexline_feature_fallback', '' );
-	$fallback_url         = isset( $fallback_setting_url ) && '' !== $fallback_setting_url ? $fallback_setting_url : $theme_level_fallback;
-	return $fallback_url;
+        $theme_level_fallback = get_theme_file_uri( 'assets/built/images/fallback.webp' );
+        $fallback_setting_url = get_option( 'flexline_feature_fallback', '' );
+        $fallback_url         = isset( $fallback_setting_url ) && '' !== $fallback_setting_url ? $fallback_setting_url : $theme_level_fallback;
+        return $fallback_url;
 }

--- a/inc/scripts.php
+++ b/inc/scripts.php
@@ -20,46 +20,46 @@ add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\flexline_enqueue_styles' );
  */
 function flexline_enqueue_styles() {
 
-	// Theme CSS.
-	wp_enqueue_style( 'flexline', get_template_directory_uri() . '/style.css', array(), THEME_VERSION );
-	// Styles.
-	wp_enqueue_style( 'flexline-base', get_template_directory_uri() . '/assets/built/css/app.css', array(), THEME_VERSION );
-	wp_enqueue_style( 'flexline-modal', get_template_directory_uri() . '/assets/built/css/modal.css', array(), THEME_VERSION );
-	// Icons Styles.
-	wp_enqueue_style( 'flexline-icons', get_template_directory_uri() . '/assets/css/icons.css', array(), THEME_VERSION );
-	// Customized Styles.
-	wp_enqueue_style( 'flexline-custom', get_template_directory_uri() . '/assets/css/customize.css', array(), THEME_VERSION );
+        // Theme CSS.
+        wp_enqueue_style( 'flexline', get_stylesheet_uri(), array(), THEME_VERSION );
+        // Styles.
+        wp_enqueue_style( 'flexline-base', get_theme_file_uri( 'assets/built/css/app.css' ), array(), THEME_VERSION );
+        wp_enqueue_style( 'flexline-modal', get_theme_file_uri( 'assets/built/css/modal.css' ), array(), THEME_VERSION );
+        // Icons Styles.
+        wp_enqueue_style( 'flexline-icons', get_theme_file_uri( 'assets/css/icons.css' ), array(), THEME_VERSION );
+        // Customized Styles.
+        wp_enqueue_style( 'flexline-custom', get_theme_file_uri( 'assets/css/customize.css' ), array(), THEME_VERSION );
 
-	// Scripts.
-	wp_enqueue_script( 'flexline-global', get_template_directory_uri() . '/assets/built/js/global.js', array(), THEME_VERSION, true );
+        // Scripts.
+        wp_enqueue_script( 'flexline-global', get_theme_file_uri( 'assets/built/js/global.js' ), array(), THEME_VERSION, true );
 	$show_menu_on_scroll    = get_option( 'flexline_show_menu_on_scroll_up', false );
 	$show_menu_all_the_time = get_option( 'flexline_show_menu_all_the_time', false );
 	if ( $show_menu_on_scroll == true || $show_menu_all_the_time == true ) {
-		wp_enqueue_script( 'flexline-headroom', get_template_directory_uri() . '/assets/js/headroom.min.js', array(), THEME_VERSION, true );
-		wp_enqueue_script( 'flexline-headroom-init', get_template_directory_uri() . '/assets/built/js/headroom.js', array(), THEME_VERSION, true );
-	}
-	wp_enqueue_script( 'flexline-load-early', get_template_directory_uri() . '/assets/built/js/load-early.js', array(), THEME_VERSION, false );
-	wp_enqueue_script( 'flexline-modal', get_template_directory_uri() . '/assets/built/js/modal.js', array(), THEME_VERSION, true );
-	wp_enqueue_script( 'flexline-slidein', get_template_directory_uri() . '/assets/built/js/slidein.js', array(), THEME_VERSION, true );
+                wp_enqueue_script( 'flexline-headroom', get_theme_file_uri( 'assets/js/headroom.min.js' ), array(), THEME_VERSION, true );
+                wp_enqueue_script( 'flexline-headroom-init', get_theme_file_uri( 'assets/built/js/headroom.js' ), array(), THEME_VERSION, true );
+        }
+        wp_enqueue_script( 'flexline-load-early', get_theme_file_uri( 'assets/built/js/load-early.js' ), array(), THEME_VERSION, false );
+        wp_enqueue_script( 'flexline-modal', get_theme_file_uri( 'assets/built/js/modal.js' ), array(), THEME_VERSION, true );
+        wp_enqueue_script( 'flexline-slidein', get_theme_file_uri( 'assets/built/js/slidein.js' ), array(), THEME_VERSION, true );
 
-	// Customized Scripts.
-	wp_enqueue_script( 'flexline-customize', get_template_directory_uri() . '/assets/js/customize.js', array(), THEME_VERSION, true );
+        // Customized Scripts.
+        wp_enqueue_script( 'flexline-customize', get_theme_file_uri( 'assets/js/customize.js' ), array(), THEME_VERSION, true );
 }
 
 /**
  * Enqueue scripts for all admin pages.
  */
 function flexline_admin_enqueue_scripts() {
-	// Styles.
-	wp_enqueue_style( 'flexline-base-admin', get_template_directory_uri() . '/assets/built/css/app.css', array(), THEME_VERSION );
-	// Modal Styles.
-	wp_enqueue_style( 'flexline-modal-admin', get_template_directory_uri() . '/assets/built/css/modal.css', array(), THEME_VERSION );
-	// Icons.
-	wp_enqueue_style( 'flexline-icons-admin', get_template_directory_uri() . '/assets/css/icons.css', array(), THEME_VERSION );
-	// Customized Styles.
-	wp_enqueue_style( 'flexline-custom-admin', get_template_directory_uri() . '/assets/css/customize.css', array(), THEME_VERSION );
+        // Styles.
+        wp_enqueue_style( 'flexline-base-admin', get_theme_file_uri( 'assets/built/css/app.css' ), array(), THEME_VERSION );
+        // Modal Styles.
+        wp_enqueue_style( 'flexline-modal-admin', get_theme_file_uri( 'assets/built/css/modal.css' ), array(), THEME_VERSION );
+        // Icons.
+        wp_enqueue_style( 'flexline-icons-admin', get_theme_file_uri( 'assets/css/icons.css' ), array(), THEME_VERSION );
+        // Customized Styles.
+        wp_enqueue_style( 'flexline-custom-admin', get_theme_file_uri( 'assets/css/customize.css' ), array(), THEME_VERSION );
 
-	wp_enqueue_script( 'flexline-global-admin', get_template_directory_uri() . '/assets/built/js/global.js', array(), THEME_VERSION, true );
+        wp_enqueue_script( 'flexline-global-admin', get_theme_file_uri( 'assets/built/js/global.js' ), array(), THEME_VERSION, true );
 	// The slide-in admin script is intentionally not enqueued.
 	// Template pattern inserter.
 	wp_enqueue_script(

--- a/inc/setup/baguette-box.php
+++ b/inc/setup/baguette-box.php
@@ -21,9 +21,9 @@ namespace FlexLine;
  * @return void
  */
 function register_assets() {
-	wp_register_style( 'baguettebox-css', get_template_directory_uri() . '/assets/baguetteBox/baguetteBox.min.css', array(), '1.11.1' );
-	wp_register_script( 'baguettebox', get_template_directory_uri() . '/assets/baguetteBox/baguetteBox.min.js', array(), '1.11.1', true );
-		wp_register_script( 'poster-gallery-helper', get_template_directory_uri() . '/assets/js/poster-gallery-helper.js', array(), THEME_VERSION, true );
+        wp_register_style( 'baguettebox-css', get_theme_file_uri( 'assets/baguetteBox/baguetteBox.min.css' ), array(), '1.11.1' );
+        wp_register_script( 'baguettebox', get_theme_file_uri( 'assets/baguetteBox/baguetteBox.min.js' ), array(), '1.11.1', true );
+                wp_register_script( 'poster-gallery-helper', get_theme_file_uri( 'assets/js/poster-gallery-helper.js' ), array(), THEME_VERSION, true );
 
 	/**
 	 * Filters the CSS selector of baguetteBox.js.

--- a/inc/setup/preload-scripts.php
+++ b/inc/setup/preload-scripts.php
@@ -13,11 +13,11 @@ namespace FlexLine;
  * @author Joel Schlotterer
  */
 function preload_scripts() {
-		printf(
-			'<link rel="%1$s" href="%2$s/assets/built/js/load-early.js" as="%3$s" />',
-			esc_attr( 'preload' ),
-			esc_url( get_template_directory_uri() ),
-			esc_attr( 'javascript' )
-		);
+                printf(
+                        '<link rel="%1$s" href="%2$s" as="%3$s" />',
+                        esc_attr( 'preload' ),
+                        esc_url( get_theme_file_uri( 'assets/built/js/load-early.js' ) ),
+                        esc_attr( 'javascript' )
+                );
 }
 add_action( 'wp_head', __NAMESPACE__ . '\preload_scripts', 1 );

--- a/inc/theme-options/theme-menu.php
+++ b/inc/theme-options/theme-menu.php
@@ -46,8 +46,8 @@ function flexline_enqueue_theme_options_assets( $hook ) {
 		return;
 	}
 
-	$base = get_template_directory_uri() . '/assets/js/';
-	wp_enqueue_script( 'tablesort', $base . 'tablesort.js', array(), '1.0', true );
-	wp_enqueue_script( 'flexline-theme-docs', $base . 'theme-docs.js', array( 'tablesort' ), '1.0', true );
+        $base = trailingslashit( get_theme_file_uri( 'assets/js' ) );
+        wp_enqueue_script( 'tablesort', $base . 'tablesort.js', array(), '1.0', true );
+        wp_enqueue_script( 'flexline-theme-docs', $base . 'theme-docs.js', array( 'tablesort' ), '1.0', true );
 }
 add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\flexline_enqueue_theme_options_assets' );


### PR DESCRIPTION
## Summary
- Replace `get_template_directory_uri()` with `get_stylesheet_uri()` for the main stylesheet
- Load all theme assets via `get_theme_file_uri()` to support child theme overrides
- Update related functions and helpers to reference theme-aware paths

## Testing
- `npm run lint-php` *(fails: vendor/bin/phpcs: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a9168ecaac832ba0b4fc58c2db3514