### PR TITLE
Use dynamic theme slug for site logo lookup

### DIFF
--- a/inc/functions/get-logo-url.php
+++ b/inc/functions/get-logo-url.php
@@ -13,8 +13,8 @@ namespace FlexLine;
  * @return string The site logo URL or an empty string if none is found.
  */
 function get_site_logo_from_block() {
-	// Assuming the header template part is used and its slug is 'header'.
-	$header_template_part = get_block_template( 'theme_slug//header', 'wp_template_part' );
+       // Assuming the header template part is used and its slug is 'header'.
+       $header_template_part = get_block_template( wp_get_theme()->get_stylesheet() . '//header', 'wp_template_part' );
 
 	if ( $header_template_part && isset( $header_template_part->content ) ) {
 		$blocks = parse_blocks( $header_template_part->content );


### PR DESCRIPTION
## Summary
- Dynamically derive the theme slug when fetching the header template part for site logo extraction.

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `npm run lint-php` *(fails: vendor/bin/phpcs not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9169f31fc832b9d6443853e28e4a5