### PR TITLE
Ensure first slide activates for fade scrollers

### DIFF
--- a/src/js/global.js
+++ b/src/js/global.js
@@ -588,6 +588,31 @@ function watchChildrenForLoop(scroller) {
 }
 
 /**
+ * Watch for toggling of the horizontal-scroller-fade class and
+ * activate the first slide when the class is added.
+ * @param {HTMLElement} scroller
+ */
+function watchFadeToggle(scroller) {
+	if (scroller.dataset.fadeObserverAttached) {
+		return;
+	}
+	let hasFade = scroller.classList.contains('horizontal-scroller-fade');
+	new window.MutationObserver(() => {
+		const nowHasFade = scroller.classList.contains(
+			'horizontal-scroller-fade'
+		);
+		if (nowHasFade && !hasFade) {
+			fadeToIndex(scroller, 0);
+		}
+		hasFade = nowHasFade;
+	}).observe(scroller, {
+		attributes: true,
+		attributeFilter: ['class'],
+	});
+	scroller.dataset.fadeObserverAttached = 'true';
+}
+
+/**
  * Rebuild all loops: first tear down any stale ones,
  * then re-init the ones that actually still have the class.
  */
@@ -636,6 +661,7 @@ function initOneScroller(scroller) {
 function scheduleScrollerInit(scroller) {
 	watchLoopToggle(scroller);
 	watchChildrenForLoop(scroller);
+	watchFadeToggle(scroller);
 
 	if (
 		isBlockEditor() &&

--- a/src/scss/blocks/horizontal-scroll-variations.scss
+++ b/src/scss/blocks/horizontal-scroll-variations.scss
@@ -175,6 +175,12 @@ body,
                                         ease-in-out;
                         }
 
+                        &:not([data-active-index]) > :first-child {
+                                opacity: 1;
+                                position: relative;
+                                pointer-events: auto;
+                        }
+
                         >*.is-active {
                                 opacity: 1;
                                 position: relative;


### PR DESCRIPTION
## Summary
- show first slide by default when fade scroller has no active index
- initialize fade scroller when the `horizontal-scroller-fade` class is added

## Testing
- ⚠️ `npm test` (missing script: "test")
- ✅ `npm run lint-js`
- ✅ `npm run lint-style`


------
https://chatgpt.com/codex/tasks/task_e_68a9c0e127e4832baca97d45d8df414b