### PR TITLE
Add fade scroller module with autoplay and accessibility controls

### DIFF
--- a/src/js/fade-scroller.js
+++ b/src/js/fade-scroller.js
@@ -1,0 +1,160 @@
+/* global getComputedStyle, IntersectionObserver */
+
+/**
+ * Initialise a scroller that crossfades its children.
+ * @param {HTMLElement} scroller
+ */
+export function initFadeScroller(scroller) {
+	if (!scroller || scroller.dataset.fadeInitialised === 'true') {
+		return;
+	}
+	scroller.dataset.fadeInitialised = 'true';
+
+	const items = Array.from(scroller.children).filter(
+		(node) => node.nodeType === 1
+	);
+	if (!items.length) {
+		return;
+	}
+
+	const cs = getComputedStyle(scroller);
+	const duration = parseInt(cs.getPropertyValue('--fl-duration'), 10) || 600;
+	const interval = parseInt(cs.getPropertyValue('--fl-interval'), 10) || 5000;
+	const easing = cs.getPropertyValue('--fl-easing').trim() || 'ease';
+	const fit = cs.getPropertyValue('--fl-media-fit').trim() || 'cover';
+
+	scroller.style.position = 'relative';
+	scroller.style.overflow = 'hidden';
+	scroller.setAttribute('aria-live', 'off');
+
+	items.forEach((item, i) => {
+		item.style.position = 'absolute';
+		item.style.inset = '0';
+		item.style.opacity = i === 0 ? '1' : '0';
+		item.style.transition = `opacity ${duration}ms ${easing}`;
+		item.style.pointerEvents = i === 0 ? '' : 'none';
+	});
+
+	items.forEach((item) => {
+		item.querySelectorAll(
+			'img, video, .wp-block-cover__image-background, .wp-block-post-featured-image img'
+		).forEach((m) => {
+			m.style.objectFit = fit;
+			m.style.width = '100%';
+			m.style.height = '100%';
+		});
+	});
+
+	let index = 0;
+
+	function updateAccessibility() {
+		items.forEach((item, i) => {
+			const active = i === index;
+			if (active) {
+				item.removeAttribute('aria-hidden');
+				item.querySelectorAll('[data-orig-tabindex]').forEach((el) => {
+					const orig = el.dataset.origTabindex;
+					if (orig === '') {
+						el.removeAttribute('tabindex');
+					} else {
+						el.setAttribute('tabindex', orig);
+					}
+					delete el.dataset.origTabindex;
+				});
+			} else {
+				item.setAttribute('aria-hidden', 'true');
+				item.querySelectorAll(
+					'a, button, input, textarea, select, [tabindex]'
+				).forEach((el) => {
+					if (!el.hasAttribute('data-orig-tabindex')) {
+						el.dataset.origTabindex =
+							el.getAttribute('tabindex') || '';
+					}
+					el.setAttribute('tabindex', '-1');
+				});
+			}
+		});
+	}
+
+	updateAccessibility();
+
+	function show(i) {
+		if (i === index) {
+			return;
+		}
+		items[index].style.opacity = '0';
+		items[index].style.pointerEvents = 'none';
+		items[i].style.opacity = '1';
+		items[i].style.pointerEvents = '';
+		index = i;
+		updateAccessibility();
+	}
+
+	function next() {
+		show((index + 1) % items.length);
+	}
+
+	let timer = null;
+	const prefersReduced = window.matchMedia(
+		'(prefers-reduced-motion: reduce)'
+	).matches;
+
+	function start() {
+		if (prefersReduced || timer) {
+			return;
+		}
+		timer = setInterval(next, interval);
+		scroller.setAttribute('aria-live', 'off');
+	}
+
+	function stop() {
+		if (timer) {
+			clearInterval(timer);
+			timer = null;
+			scroller.setAttribute('aria-live', 'polite');
+		}
+	}
+
+	scroller.addEventListener('mouseenter', stop);
+	scroller.addEventListener('mouseleave', start);
+	scroller.addEventListener('focusin', stop);
+	scroller.addEventListener('focusout', (e) => {
+		if (!scroller.contains(e.relatedTarget)) {
+			start();
+		}
+	});
+
+	start();
+
+	if (!cs.getPropertyValue('--fl-height').trim()) {
+		const measure = () => {
+			let max = 0;
+			items.forEach((item) => {
+				const h = item.offsetHeight;
+				if (h > max) {
+					max = h;
+				}
+			});
+			if (max) {
+				scroller.style.setProperty('--fl-height', `${max}px`);
+			}
+		};
+
+		measure();
+		window.addEventListener('load', measure);
+		scroller.querySelectorAll('img, video').forEach((m) => {
+			if (m.complete || m.readyState >= 2) {
+				measure();
+			} else {
+				m.addEventListener('load', measure);
+				m.addEventListener('loadedmetadata', measure);
+			}
+		});
+		const io = new IntersectionObserver((entries) => {
+			if (entries[0].isIntersecting) {
+				measure();
+			}
+		});
+		io.observe(scroller);
+	}
+}

--- a/src/js/global.js
+++ b/src/js/global.js
@@ -1,5 +1,7 @@
 /* global requestAnimationFrame */
 
+import { initFadeScroller } from './fade-scroller';
+
 // Horizontal Scroll block behaviour – front‑end + block‑editor compatible
 
 // Helper ──────────────────────────────────────────────────────────────────────
@@ -643,6 +645,10 @@ function initScrollers() {
 	document
 		.querySelectorAll('.is-style-horizontal-scroll')
 		.forEach(scheduleScrollerInit);
+
+	document
+		.querySelectorAll('[data-flexline-transition="fade"]')
+		.forEach(initFadeScroller);
 	initInfiniteLoops();
 }
 
@@ -655,13 +661,34 @@ if (isBlockEditor()) {
 	const bodyObserver = new window.MutationObserver((records) => {
 		for (const rec of records) {
 			for (const node of rec.addedNodes) {
+				if (node.nodeType !== 1) {
+					continue;
+				}
+
 				if (
-					node.nodeType === 1 &&
 					node.classList.contains('is-style-horizontal-scroll') &&
 					!node.dataset._scrollerInitQueued
 				) {
 					node.dataset._scrollerInitQueued = 'true';
 					scheduleScrollerInit(node);
+				}
+
+				if (node.matches?.('[data-flexline-transition="fade"]')) {
+					initFadeScroller(node);
+				}
+
+				if (node.querySelectorAll) {
+					node.querySelectorAll(
+						'.is-style-horizontal-scroll'
+					).forEach((el) => {
+						if (!el.dataset._scrollerInitQueued) {
+							el.dataset._scrollerInitQueued = 'true';
+							scheduleScrollerInit(el);
+						}
+					});
+					node.querySelectorAll(
+						'[data-flexline-transition="fade"]'
+					).forEach(initFadeScroller);
 				}
 			}
 		}


### PR DESCRIPTION
## Summary
- add fade-scroller module that crossfades items, handles autoplay, object-fit, and dynamic height
- integrate fade scroller initialization into existing global scroller setup

## Testing
- `npm run lint-js`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aa244277f0832b92c4b9f71724cd33