### PR TITLE
Add fade transition scroller module

### DIFF
--- a/src/js/fader.js
+++ b/src/js/fader.js
@@ -1,0 +1,107 @@
+/**
+ * Initialize a single fade scroller.
+ *
+ * @param {HTMLElement} scroller Container with fade transition class.
+ */
+function initOneFader(scroller) {
+	if (scroller._faderCleanup) {
+		scroller._faderCleanup();
+	}
+
+	const slides = Array.from(scroller.children);
+	if (!slides.length) {
+		return;
+	}
+
+	const interval = parseInt(
+		scroller.getAttribute('data-scroll-interval') || '5000',
+		10
+	);
+	const duration = parseInt(
+		scroller.getAttribute('data-scroll-speed') || '600',
+		10
+	);
+
+	let index = 0;
+	const reducedMotion = window.matchMedia(
+		'(prefers-reduced-motion: reduce)'
+	).matches;
+
+	slides.forEach((slide, i) => {
+		slide.style.opacity = i === 0 ? '1' : '0';
+		slide.style.transition = `opacity ${duration}ms`;
+		slide.setAttribute('tabindex', i === 0 ? '0' : '-1');
+		if (i !== 0) {
+			slide.setAttribute('aria-hidden', 'true');
+		} else {
+			slide.removeAttribute('aria-hidden');
+		}
+	});
+
+	function show(newIndex) {
+		slides.forEach((slide, i) => {
+			const active = i === newIndex;
+			slide.style.opacity = active ? '1' : '0';
+			slide.setAttribute('tabindex', active ? '0' : '-1');
+			if (active) {
+				slide.removeAttribute('aria-hidden');
+			} else {
+				slide.setAttribute('aria-hidden', 'true');
+			}
+		});
+		index = newIndex;
+	}
+
+	function next() {
+		show((index + 1) % slides.length);
+	}
+
+	let timer = null;
+
+	function play() {
+		if (reducedMotion || timer) {
+			return;
+		}
+		scroller.setAttribute('aria-live', 'polite');
+		timer = setInterval(next, interval);
+	}
+
+	function pause() {
+		if (timer) {
+			clearInterval(timer);
+			timer = null;
+		}
+		scroller.setAttribute('aria-live', 'off');
+	}
+
+	scroller.addEventListener('mouseenter', pause);
+	scroller.addEventListener('mouseleave', play);
+	scroller.addEventListener('focusin', pause);
+	scroller.addEventListener('focusout', play);
+
+	if (!reducedMotion) {
+		play();
+	} else {
+		scroller.setAttribute('aria-live', 'off');
+	}
+
+	scroller._faderCleanup = () => {
+		pause();
+		scroller.removeEventListener('mouseenter', pause);
+		scroller.removeEventListener('mouseleave', play);
+		scroller.removeEventListener('focusin', pause);
+		scroller.removeEventListener('focusout', play);
+		delete scroller._faderCleanup;
+	};
+}
+
+/**
+ * Initialise all fade scrollers on the page.
+ */
+function initFaders() {
+	document
+		.querySelectorAll('.horizontal-scroller-transition-fade')
+		.forEach(initOneFader);
+}
+
+export { initFaders, initOneFader };

--- a/src/js/global.js
+++ b/src/js/global.js
@@ -1,4 +1,5 @@
 /* global requestAnimationFrame */
+import { initFaders } from './fader';
 
 // Horizontal Scroll block behaviour – front‑end + block‑editor compatible
 
@@ -647,8 +648,14 @@ function initScrollers() {
 }
 
 // on DOMContentLoaded / load you just call:
-document.addEventListener('DOMContentLoaded', initScrollers);
-window.addEventListener('load', initScrollers);
+document.addEventListener('DOMContentLoaded', () => {
+	initScrollers();
+	initFaders();
+});
+window.addEventListener('load', () => {
+	initScrollers();
+	initFaders();
+});
 
 // 2. Also watch for new scrollers popping into the editor
 if (isBlockEditor()) {
@@ -656,14 +663,27 @@ if (isBlockEditor()) {
 		for (const rec of records) {
 			for (const node of rec.addedNodes) {
 				if (
-					node.nodeType === 1 &&
-					node.classList.contains(
-						'horizontal-scroller-transition-slide'
+					(node.nodeType === 1 &&
+						node.classList.contains(
+							'horizontal-scroller-transition-slide'
+						) &&
+						!node.dataset._scrollerInitQueued) ||
+					(node.classList.contains(
+						'horizontal-scroller-transition-fade'
 					) &&
-					!node.dataset._scrollerInitQueued
+						!node.dataset._faderInitQueued)
 				) {
-					node.dataset._scrollerInitQueued = 'true';
-					scheduleScrollerInit(node);
+					if (
+						node.classList.contains(
+							'horizontal-scroller-transition-slide'
+						)
+					) {
+						node.dataset._scrollerInitQueued = 'true';
+						scheduleScrollerInit(node);
+					} else {
+						node.dataset._faderInitQueued = 'true';
+						initFaders();
+					}
 				}
 			}
 		}
@@ -677,7 +697,10 @@ if (isBlockEditor()) {
 		let t;
 		wp.data.subscribe(() => {
 			clearTimeout(t);
-			t = setTimeout(() => initScrollers(), 200);
+			t = setTimeout(() => {
+				initScrollers();
+				initFaders();
+			}, 200);
 		});
 	});
 }


### PR DESCRIPTION
## Summary
- add `fader.js` to handle `.horizontal-scroller-transition-fade` elements with cross‑fade autoplay
- hook fade initializer into global script and editor observers

## Testing
- `npm run lint-js`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aa7a9e5af0832b9773ca6b70dd737d