### PR TITLE
docs: document fade transition for horizontal scroller

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,3 +114,28 @@ The optional **FlexLine Utilities Plugin** adds helpful shortcodes and tools tha
 - `[flexline_loginout]` – show a login or logout link depending on the visitor.
 
 [Download the FlexLine Utilities Plugin](https://github.com/wpengine/flexline/releases/latest/download/flexline-utilities.zip) and install it like any other WordPress plugin.
+
+## Fade Transition for Horizontal Scrollers
+
+The horizontal scroller supports a **Fade** transition that cross‑fades items instead of sliding. When this mode is enabled you can:
+
+- Define a fixed container height.
+- Choose how media is displayed (`Fill` or `Fit`).
+- Enable autoplay and optional pause‑on‑hover.
+
+### Columns example
+
+```html
+<!-- wp:columns {"className":"is-style-horizontal-scroll horizontal-scroller-transition-fade","enableHorizontalScroller":true,"transitionType":"fade","fadeHeight":"300px","fadeMediaDisplay":"cover","scrollAuto":true} -->
+    <!-- wp:column --><!-- /wp:column -->
+    <!-- wp:column --><!-- /wp:column -->
+<!-- /wp:columns -->
+```
+
+### Post Template example
+
+```html
+<!-- wp:post-template {"className":"is-style-horizontal-scroll horizontal-scroller-transition-fade","enableHorizontalScroller":true,"transitionType":"fade","fadeHeight":"300px","fadeMediaDisplay":"cover","scrollAuto":true} /-->
+```
+
+`horizontal-scroller-transition-fade` is required for the fade effect. Setting `fadeMediaDisplay` to `"contain"` will add the `horizontal-fader-media-contain` class instead of `horizontal-fader-media-cover`.

--- a/inc/theme-options/render-theme-docs.php
+++ b/inc/theme-options/render-theme-docs.php
@@ -133,18 +133,20 @@ if ( ! function_exists( __NAMESPACE__ . '\\flexline_render_documentation_tab' ) 
 				'attributes' => array(
 					array(
 						'name'        => 'Horizontal Scroller',
-						'description' => 'Turns the container into a swipeable carousel; subordinate toggles control nav, auto‑scroll, etc. <ul>' .
-							'<li>Show Arrow Nav</li>' .
-							'<li>Position Buttons Over Scroller</li>' .
-							'<li>Scroll transition in milliseconds</li>' .
-							'<li>Loop</li>' .
-							'<li>Auto Scroll</li>' .
-							'<li>Hide Pause Button</li>' .
-							'<li>Scroll interval in milliseconds</li>' .
-							'<li>Hide Scrollbar</li>' .
-							'<li>Pause on Hover</li>' .
-							'<li>Button Positions / Colors</li>' .
-							'</ul>',
+                                                'description' => 'Turns the container into a swipeable carousel or fader; subordinate toggles control nav, auto‑scroll, etc. <ul>' .
+                                                        '<li>Transition: Slide or Fade</li>' .
+                                                        '<li>Fade height & media display (Fill/Fit)</li>' .
+                                                        '<li>Show Arrow Nav</li>' .
+                                                        '<li>Position Buttons Over Scroller</li>' .
+                                                        '<li>Scroll transition speed in milliseconds</li>' .
+                                                        '<li>Loop</li>' .
+                                                        '<li>Auto Scroll / Autoplay</li>' .
+                                                        '<li>Scroll interval in milliseconds</li>' .
+                                                        '<li>Hide Pause Button</li>' .
+                                                        '<li>Hide Scrollbar</li>' .
+                                                        '<li>Pause on Hover</li>' .
+                                                        '<li>Button Positions / Colors</li>' .
+                                                        '</ul>',
 					),
 					array(
 						'name'        => 'Stack at Tablet',
@@ -160,18 +162,20 @@ if ( ! function_exists( __NAMESPACE__ . '\\flexline_render_documentation_tab' ) 
 				'attributes' => array(
 					array(
 						'name'        => 'Horizontal Scroller',
-						'description' => 'Turns the container into a swipeable carousel; subordinate toggles control nav, auto‑scroll, etc. <ul>' .
-							'<li>Show Arrow Nav</li>' .
-							'<li>Position Buttons Over Scroller</li>' .
-							'<li>Scroll transition in milliseconds</li>' .
-							'<li>Loop</li>' .
-							'<li>Auto Scroll</li>' .
-							'<li>Hide Pause Button</li>' .
-							'<li>Scroll interval in milliseconds</li>' .
-							'<li>Hide Scrollbar</li>' .
-							'<li>Pause on Hover</li>' .
-							'<li>Button Positions / Colors</li>' .
-							'</ul>',
+                                                'description' => 'Turns the container into a swipeable carousel or fader; subordinate toggles control nav, auto‑scroll, etc. <ul>' .
+                                                        '<li>Transition: Slide or Fade</li>' .
+                                                        '<li>Fade height & media display (Fill/Fit)</li>' .
+                                                        '<li>Show Arrow Nav</li>' .
+                                                        '<li>Position Buttons Over Scroller</li>' .
+                                                        '<li>Scroll transition speed in milliseconds</li>' .
+                                                        '<li>Loop</li>' .
+                                                        '<li>Auto Scroll / Autoplay</li>' .
+                                                        '<li>Scroll interval in milliseconds</li>' .
+                                                        '<li>Hide Pause Button</li>' .
+                                                        '<li>Hide Scrollbar</li>' .
+                                                        '<li>Pause on Hover</li>' .
+                                                        '<li>Button Positions / Colors</li>' .
+                                                        '</ul>',
 					),
 				),
 			),

--- a/readme.txt
+++ b/readme.txt
@@ -16,6 +16,31 @@ With its clean, minimal design and powerful feature set, FlexLine enables agenci
 
 For additional helper features, install the optional **FlexLine Utilities Plugin**. It can be downloaded from https://github.com/wpengine/flexline/releases/latest/download/flexline-utilities.zip and provides shortcodes like `[flexline_year]` for the current year or `[flexline_loginout]` to output login and logout links.
 
+== Horizontal Scroller Fade Transition ==
+
+The horizontal scroller supports a **Fade** transition that cross-fades items instead of sliding.
+
+* Set a custom container height.
+* Choose how media is displayed: Fill (`horizontal-fader-media-cover`) or Fit (`horizontal-fader-media-contain`).
+* Enable autoplay with optional pause-on-hover or hidden pause button.
+
+=== Columns example ===
+
+```
+<!-- wp:columns {"className":"is-style-horizontal-scroll horizontal-scroller-transition-fade","enableHorizontalScroller":true,"transitionType":"fade","fadeHeight":"300px","fadeMediaDisplay":"cover","scrollAuto":true} -->
+    <!-- wp:column --><!-- /wp:column -->
+    <!-- wp:column --><!-- /wp:column -->
+<!-- /wp:columns -->
+```
+
+=== Post Template example ===
+
+```
+<!-- wp:post-template {"className":"is-style-horizontal-scroll horizontal-scroller-transition-fade","enableHorizontalScroller":true,"transitionType":"fade","fadeHeight":"300px","fadeMediaDisplay":"cover","scrollAuto":true} /-->
+```
+
+`horizontal-scroller-transition-fade` is required for the fade effect.
+
 == Bundled Assets and Licenses ==
 
 * Google Fonts (Cabin, Calistoga, Crimson Text, Jost, Lato, Quattrocento, Quicksand, REM, Raleway, Source Sans 3, Sulphur Point, Varela) - SIL Open Font License 1.1 (see assets/fonts/*/OFL.txt)


### PR DESCRIPTION
## Summary
- document fade transition in main README and theme readme
- add fade transition guidance to theme documentation

## Testing
- `npm test` (fails: Missing script "test")
- `composer test` (fails: Command "test" is not defined)
- `npm run lint` (fails: vendor/bin/phpcs: not found)


------
https://chatgpt.com/codex/tasks/task_e_68aa7abb7448832b97b412ee41439f4c