### PR TITLE
Refine scroller wrapper logic

### DIFF
--- a/src/js/global.js
+++ b/src/js/global.js
@@ -218,6 +218,7 @@ function setupScrollerButtons(scroller) {
 			if (existing) {
 				existing.remove();
 			}
+			removeWrapper(scroller);
 			delete scroller.dataset.buttonsInitialised; // reset so we can rebuild later
 		} else {
 			return; // nothing changed – keep existing buttons
@@ -226,6 +227,7 @@ function setupScrollerButtons(scroller) {
 
 	// If neither nav nor pause is requested, we are done.
 	if (!hasNav && !showPause) {
+		removeWrapper(scroller);
 		return;
 	}
 
@@ -436,13 +438,6 @@ function setupStatusObserver(scroller) {
 // 6.  Public initialiser helpers so we can call them multiple times.
 //------------------------------------------------------------------
 function initScroller(scroller) {
-	/*  First, guarantee wrapper status is in sync with the presence of the style-class. */
-	if (scroller.classList.contains('horizontal-scroller-transition-slide')) {
-		ensureWrapper(scroller);
-	} else {
-		removeWrapper(scroller);
-	}
-
 	setupScrollerButtons(scroller); // may add / remove button UI
 	setupStatusObserver(scroller);
 }


### PR DESCRIPTION
## Summary
- Only wrap scrollers when navigation or pause controls are active
- Remove wrapper when controls are absent to avoid leftover markup

## Testing
- `npm run lint-js`


------
https://chatgpt.com/codex/tasks/task_e_68aa83814840832b9d2e17ada95f5df1