### PR TITLE
Add horizontal fade variation styles

### DIFF
--- a/src/scss/blocks/horizontal-scroll-variations.scss
+++ b/src/scss/blocks/horizontal-scroll-variations.scss
@@ -180,6 +180,64 @@ body,
 
 	}
 
+	.is-style-horizontal-fade {
+		position: relative;
+		overflow: hidden;
+		height: var(--horizontal-fader-height, 70svh);
+
+		>* {
+			position: absolute;
+			inset: 0;
+			width: 100%;
+			height: 100%;
+			opacity: 0;
+			pointer-events: none;
+		}
+
+		>.is-active {
+			opacity: 1;
+			pointer-events: auto;
+		}
+
+		&.horizontal-fader-media-normal {
+			img,
+			video,
+			.wp-block-post-featured-image img {
+				object-fit: initial;
+			}
+
+			.wp-block-cover__background,
+			.wp-block-cover__image-background {
+				background-size: auto;
+			}
+		}
+
+		&.horizontal-fader-media-cover {
+			img,
+			video,
+			.wp-block-post-featured-image img {
+				object-fit: cover;
+			}
+
+			.wp-block-cover__background,
+			.wp-block-cover__image-background {
+				background-size: cover;
+			}
+		}
+
+		&.horizontal-fader-media-contain {
+			img,
+			video,
+			.wp-block-post-featured-image img {
+				object-fit: contain;
+			}
+
+			.wp-block-cover__background,
+			.wp-block-cover__image-background {
+				background-size: contain;
+			}
+		}
+	}
 	.is-horizontal-scroll-btn {
 		color: var(--wp--preset--color--base);
 		background-color: var(--wp--custom--deco-color);


### PR DESCRIPTION
## Summary
- add `.is-style-horizontal-fade` rules for fade-style horizontal scrollers
- support media fit modifiers `horizontal-fader-media-normal|cover|contain`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab10cb9bb8832baa9abd8100243e38