### PR TITLE
Support fade transition wrappers and rebuild navigation

### DIFF
--- a/src/js/global.js
+++ b/src/js/global.js
@@ -174,40 +174,50 @@ function removeWrapper(scroller) {
 // 4.  Nav / pause buttons.
 //------------------------------------------------------------------
 function setupScrollerButtons(scroller) {
-	if (!scroller.dataset.classObserverAttached && isBlockEditor()) {
-		new window.MutationObserver(() =>
-			setupScrollerButtons(scroller)
-		).observe(scroller, { attributes: true, attributeFilter: ['class'] });
-		scroller.dataset.classObserverAttached = 'true';
-	}
-	// ──────────────────────────────────────────────────────────────────────
-	// 0. Determine current option state *up‑front*
-	//    (We need this before any early‑exit based on buttonsInitialised.)
-	// ──────────────────────────────────────────────────────────────────────
-	const hasNav = scroller.classList.contains(
-		'horizontal-scroller-navigation'
-	);
-	const showPause =
-		scroller.classList.contains('horizontal-scroller-auto') &&
-		!scroller.classList.contains('horizontal-scroller-hide-pause-button');
+        if (!scroller.dataset.classObserverAttached && isBlockEditor()) {
+                new window.MutationObserver(() =>
+                        initScroller(scroller)
+                ).observe(scroller, { attributes: true, attributeFilter: ['class'] });
+                scroller.dataset.classObserverAttached = 'true';
+        }
+        // ──────────────────────────────────────────────────────────────────────
+        // 0. Determine current option state *up‑front*
+        //    (We need this before any early‑exit based on buttonsInitialised.)
+        // ──────────────────────────────────────────────────────────────────────
+        const currentStyle = scroller.classList.contains(
+                'is-style-horizontal-fade'
+        )
+                ? 'fade'
+                : scroller.classList.contains('is-style-horizontal-scroll')
+                        ? 'slide'
+                        : 'none';
+        const hasNav = scroller.classList.contains(
+                'horizontal-scroller-navigation'
+        );
+        const showPause =
+                scroller.classList.contains('horizontal-scroller-auto') &&
+                !scroller.classList.contains('horizontal-scroller-hide-pause-button');
 
-	// If the nav / pause state changed since the last run, force a rebuild
-	if (
-		scroller.dataset.buttonsInitialised === 'true' &&
-		(hasNav !== (scroller.dataset.prevHasNav === 'true') ||
-			showPause !== (scroller.dataset.prevShowPause === 'true'))
-	) {
-		const existing = scroller.parentNode.querySelector(
-			'.horizontal-scroller-nav-buttons'
-		);
-		if (existing) {
-			existing.remove();
-		}
-		delete scroller.dataset.buttonsInitialised; // let the function fall through and rebuild
-	}
-	// Remember current state for the next toggle
-	scroller.dataset.prevHasNav = hasNav;
-	scroller.dataset.prevShowPause = showPause;
+        // If the nav / pause state or transition style changed since the last run,
+        // force a rebuild.
+        if (
+                scroller.dataset.buttonsInitialised === 'true' &&
+                (hasNav !== (scroller.dataset.prevHasNav === 'true') ||
+                        showPause !== (scroller.dataset.prevShowPause === 'true') ||
+                        currentStyle !== scroller.dataset.prevStyle)
+        ) {
+                const existing = scroller.parentNode.querySelector(
+                        '.horizontal-scroller-nav-buttons'
+                );
+                if (existing) {
+                        existing.remove();
+                }
+                delete scroller.dataset.buttonsInitialised; // let the function fall through and rebuild
+        }
+        // Remember current state for the next toggle
+        scroller.dataset.prevHasNav = hasNav;
+        scroller.dataset.prevShowPause = showPause;
+        scroller.dataset.prevStyle = currentStyle;
 
 	if (scroller.dataset.buttonsInitialised === 'true') {
 		if (!hasNav && !showPause) {
@@ -435,15 +445,18 @@ function setupStatusObserver(scroller) {
 // 6.  Public initialiser helpers so we can call them multiple times.
 //------------------------------------------------------------------
 function initScroller(scroller) {
-	/*  First, guarantee wrapper status is in sync with the presence of the style-class. */
-	if (scroller.classList.contains('is-style-horizontal-scroll')) {
-		ensureWrapper(scroller);
-	} else {
-		removeWrapper(scroller);
-	}
+        /*  First, guarantee wrapper status is in sync with the presence of the style-class. */
+        if (
+                scroller.classList.contains('is-style-horizontal-scroll') ||
+                scroller.classList.contains('is-style-horizontal-fade')
+        ) {
+                ensureWrapper(scroller);
+        } else {
+                removeWrapper(scroller);
+        }
 
-	setupScrollerButtons(scroller); // may add / remove button UI
-	setupStatusObserver(scroller);
+        setupScrollerButtons(scroller); // may add / remove button UI
+        setupStatusObserver(scroller);
 }
 
 /**
@@ -640,10 +653,12 @@ function scheduleScrollerInit(scroller) {
  * it off to our scheduler.
  */
 function initScrollers() {
-	document
-		.querySelectorAll('.is-style-horizontal-scroll')
-		.forEach(scheduleScrollerInit);
-	initInfiniteLoops();
+        document
+                .querySelectorAll(
+                        '.is-style-horizontal-scroll, .is-style-horizontal-fade'
+                )
+                .forEach(scheduleScrollerInit);
+        initInfiniteLoops();
 }
 
 // on DOMContentLoaded / load you just call:
@@ -656,13 +671,18 @@ if (isBlockEditor()) {
 		for (const rec of records) {
 			for (const node of rec.addedNodes) {
 				if (
-					node.nodeType === 1 &&
-					node.classList.contains('is-style-horizontal-scroll') &&
-					!node.dataset._scrollerInitQueued
-				) {
-					node.dataset._scrollerInitQueued = 'true';
-					scheduleScrollerInit(node);
-				}
+                                        node.nodeType === 1 &&
+                                        (node.classList.contains(
+                                                'is-style-horizontal-scroll'
+                                        ) ||
+                                                node.classList.contains(
+                                                        'is-style-horizontal-fade'
+                                                )) &&
+                                        !node.dataset._scrollerInitQueued
+                                ) {
+                                        node.dataset._scrollerInitQueued = 'true';
+                                        scheduleScrollerInit(node);
+                                }
 			}
 		}
 	});


### PR DESCRIPTION
## Summary
- handle `.is-style-horizontal-fade` in scroller initialization and wrapper logic
- reinitialize scrollers and rebuild nav when slide/fade styles toggle
- detect fade style when scheduling scroller initialization

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint-js`

------
https://chatgpt.com/codex/tasks/task_e_68ab10cc68d4832b92afee7106b47751