### PR TITLE
Skip status observer for fade scrollers

### DIFF
--- a/src/js/global.js
+++ b/src/js/global.js
@@ -51,6 +51,8 @@ function switchFadeSlide(scroller, newIndex) {
 	items.forEach((item, i) => {
 		const active = i === index;
 		item.classList.toggle('is-active', active);
+		// With fade transitions we manage aria-hidden manually to keep
+		// non-visible slides out of the accessibility tree.
 		item.setAttribute('aria-hidden', active ? 'false' : 'true');
 		item.setAttribute('tabindex', active ? '0' : '-1');
 	});
@@ -497,6 +499,12 @@ function buildThresholdList() {
 }
 
 function setupStatusObserver(scroller) {
+	// Fade style scrollers handle slide visibility manually when the
+	// active slide changes, so the intersection observer is unnecessary.
+	if (scroller.classList.contains('is-style-horizontal-fade')) {
+		return;
+	}
+
 	const observer = new window.IntersectionObserver(
 		(entries) => {
 			entries.forEach((entry) => {


### PR DESCRIPTION
## Summary
- Bypass intersection observer setup for horizontal fade scrollers
- Clarify fade slide navigation to manually toggle `aria-hidden`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: vendor/bin/phpcs not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6b553760832b8ba98b9683675696