### PR TITLE
Support custom fade height for horizontal scroller

### DIFF
--- a/inc/blocks/block-extensions.php
+++ b/inc/blocks/block-extensions.php
@@ -179,25 +179,31 @@ function flexline_block_customizations_render( $block_content, $block ) {
 		}
 	}
 
-	if ( isset( $block['attrs']['enableHorizontalScroller'] ) && $block['attrs']['enableHorizontalScroller'] ) {
+        if ( isset( $block['attrs']['enableHorizontalScroller'] ) && $block['attrs']['enableHorizontalScroller'] ) {
 
-		$block['attrs']['scrollAuto'] = isset( $block['attrs']['scrollAuto'] ) ? $block['attrs']['scrollAuto'] : false;
-		if ( isset( $block['attrs']['enableHorizontalScroller'] ) && $block['attrs']['enableHorizontalScroller'] && $block['attrs']['scrollAuto'] ) {
-			$block['attrs']['scrollSpeed'] = isset( $block['attrs']['scrollSpeed'] ) ? $block['attrs']['scrollSpeed'] : 4000;
-			$data_scroll_interval          = 'data-scroll-interval="' . $block['attrs']['scrollSpeed'] . '"';
-			$search_string                 = '>';
-			$replace_string                = ' ' . $data_scroll_interval . '>';
-			$block_content                 = str_replace_first( $search_string, $replace_string, $block_content );
-		}
+                $block['attrs']['scrollAuto'] = isset( $block['attrs']['scrollAuto'] ) ? $block['attrs']['scrollAuto'] : false;
+                if ( isset( $block['attrs']['enableHorizontalScroller'] ) && $block['attrs']['enableHorizontalScroller'] && $block['attrs']['scrollAuto'] ) {
+                        $block['attrs']['scrollSpeed'] = isset( $block['attrs']['scrollSpeed'] ) ? $block['attrs']['scrollSpeed'] : 4000;
+                        $data_scroll_interval          = 'data-scroll-interval="' . $block['attrs']['scrollSpeed'] . '"';
+                        $search_string                 = '>';
+                        $replace_string                = ' ' . $data_scroll_interval . '>';
+                        $block_content                 = str_replace_first( $search_string, $replace_string, $block_content );
+                }
 
-		if ( isset( $block['attrs']['enableHorizontalScroller'] ) && $block['attrs']['enableHorizontalScroller'] && isset( $block['attrs']['transitionDuration'] ) ) {
-			$block['attrs']['transitionDuration'] = isset( $block['attrs']['transitionDuration'] ) ? $block['attrs']['transitionDuration'] : 500;
-			$data_scroll_interval                 = 'data-scroll-speed="' . $block['attrs']['transitionDuration'] . '"';
-			$search_string                        = '>';
-			$replace_string                       = ' ' . $data_scroll_interval . '>';
-			$block_content                        = str_replace_first( $search_string, $replace_string, $block_content );
-		}
-	}
+                if ( isset( $block['attrs']['enableHorizontalScroller'] ) && $block['attrs']['enableHorizontalScroller'] && isset( $block['attrs']['transitionDuration'] ) ) {
+                        $block['attrs']['transitionDuration'] = isset( $block['attrs']['transitionDuration'] ) ? $block['attrs']['transitionDuration'] : 500;
+                        $data_scroll_interval                 = 'data-scroll-speed="' . $block['attrs']['transitionDuration'] . '"';
+                        $search_string                        = '>';
+                        $replace_string                       = ' ' . $data_scroll_interval . '>';
+                        $block_content                        = str_replace_first( $search_string, $replace_string, $block_content );
+                }
+
+                if ( isset( $block['attrs']['fadeHeight'] ) && ! empty( $block['attrs']['fadeHeight'] ) ) {
+                        $fade_height   = esc_attr( $block['attrs']['fadeHeight'] );
+                        $style_rules   = '--fade-height: ' . $fade_height . '; --horizontal-fader-height: ' . $fade_height . ';';
+                        $block_content = flexline_merge_inline_style( $block_content, $style_rules );
+                }
+        }
 
 	// **Add Unique Class and Styles for Content Shift**.
 	if ( isset( $block['attrs']['useContentShift'] ) && $block['attrs']['useContentShift'] ) {

--- a/src/js/blocks/controls/index.js
+++ b/src/js/blocks/controls/index.js
@@ -109,6 +109,20 @@ const withCustomControls = createHigherOrderComponent((BlockEdit) => {
 			handler.useHooks(props);
 		}
 
+		if (!props.wrapperProps) {
+			props.wrapperProps = {};
+		}
+
+		if (
+			props.attributes.enableHorizontalScroller &&
+			props.attributes.fadeHeight
+		) {
+			props.wrapperProps.style = {
+				...(props.wrapperProps.style || {}),
+				'--fade-height': props.attributes.fadeHeight,
+			};
+		}
+
 		useEffect(() => {
 			const removedClasses = [];
 			const newClasses = [];


### PR DESCRIPTION
## Summary
- Apply fade height to horizontal scroller on front end by merging CSS variables `--fade-height` and `--horizontal-fader-height`
- Inject `--fade-height` style in editor preview when scroller is enabled

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: vendor/bin/phpcs: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68abc6ff5b78832ba5771a4c1b0b7e21