### PR TITLE
Compute horizontal fade height from header size

### DIFF
--- a/src/js/global.js
+++ b/src/js/global.js
@@ -214,13 +214,19 @@ function setupFade(scroller) {
 	}
 	const wrapper = ensureWrapper(scroller);
 
-	const styles = window.getComputedStyle(scroller);
-	const height =
-		styles.getPropertyValue('--fade-height').trim() ||
-		styles.getPropertyValue('--horizontal-fader-height').trim() ||
-		'65svh';
+	function setHeight() {
+		const styles = window.getComputedStyle(scroller);
+		const header = document.querySelector('header.site-header');
+		const headerHeight = header ? header.offsetHeight : 0;
+		const height =
+			styles.getPropertyValue('--fade-height').trim() ||
+			styles.getPropertyValue('--horizontal-fader-height').trim() ||
+			`calc(100vh - ${headerHeight}px)`;
+		wrapper.style.setProperty('--horizontal-fader-height', height);
+	}
 
-	wrapper.style.setProperty('--horizontal-fader-height', height);
+	setHeight();
+	window.addEventListener('resize', setHeight);
 
 	const speed = parseInt(
 		scroller.getAttribute('data-scroll-speed') || '',


### PR DESCRIPTION
## Summary
- derive horizontal fade height from header height
- update fade height on window resize

## Testing
- `npm run lint-js`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ad15f06d98832bad7158246fb00a0d