### PR TITLE
Use distinct variables for scroll attributes

### DIFF
--- a/inc/blocks/block-extensions.php
+++ b/inc/blocks/block-extensions.php
@@ -190,13 +190,13 @@ function flexline_block_customizations_render( $block_content, $block ) {
 				$block_content                 = str_replace_first( $search_string, $replace_string, $block_content );
 		}
 
-		if ( isset( $block['attrs']['enableHorizontalScroller'] ) && $block['attrs']['enableHorizontalScroller'] && isset( $block['attrs']['transitionDuration'] ) ) {
-				$block['attrs']['transitionDuration'] = isset( $block['attrs']['transitionDuration'] ) ? $block['attrs']['transitionDuration'] : 500;
-				$data_scroll_interval                 = 'data-scroll-speed="' . $block['attrs']['transitionDuration'] . '"';
-				$search_string                        = '>';
-				$replace_string                       = ' ' . $data_scroll_interval . '>';
-				$block_content                        = str_replace_first( $search_string, $replace_string, $block_content );
-		}
+                if ( isset( $block['attrs']['enableHorizontalScroller'] ) && $block['attrs']['enableHorizontalScroller'] && isset( $block['attrs']['transitionDuration'] ) ) {
+                                $block['attrs']['transitionDuration'] = isset( $block['attrs']['transitionDuration'] ) ? $block['attrs']['transitionDuration'] : 500;
+                                $data_scroll_speed                    = 'data-scroll-speed="' . $block['attrs']['transitionDuration'] . '"';
+                                $search_string                        = '>';
+                                $replace_string                       = ' ' . $data_scroll_speed . '>';
+                                $block_content                        = str_replace_first( $search_string, $replace_string, $block_content );
+                }
 
 		if ( isset( $block['attrs']['fadeHeight'] ) && ! empty( $block['attrs']['fadeHeight'] ) ) {
 				$fade_height   = esc_attr( $block['attrs']['fadeHeight'] );


### PR DESCRIPTION
## Summary
- use `$data_scroll_interval` and `$data_scroll_speed` for distinct scroll attributes

## Testing
- `composer install` *(fails: required GitHub token)*
- `npm run lint-php` *(fails: vendor/bin/phpcs: not found)*
- `npm test` *(fails: Missing script "test")*
- `php -l inc/blocks/block-extensions.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad283d20e4832ba32e2aee4ccb66c6