### PR TITLE
Skip fade initialization inside block editor

### DIFF
--- a/src/js/horizontal-fade.js
+++ b/src/js/horizontal-fade.js
@@ -72,6 +72,16 @@ export function setupFade(scroller) {
 	if (!scroller.classList.contains('is-style-horizontal-fade')) {
 		return false;
 	}
+
+	if (isBlockEditor()) {
+		Array.from(scroller.children).forEach((item) => {
+			item.classList.remove('is-active');
+			item.removeAttribute('aria-hidden');
+			item.removeAttribute('tabindex');
+		});
+		return false;
+	}
+
 	const wrapper = ensureWrapper(scroller);
 
 	function setHeight() {
@@ -96,7 +106,7 @@ export function setupFade(scroller) {
 		scroller.style.setProperty('--horizontal-fade-duration', `${speed}ms`);
 	}
 
-	// Avoid resetting an already active slide (e.g., in the block editor).
+	// Avoid resetting an already active slide.
 	const hasActiveChild = Array.from(scroller.children).some((c) =>
 		c.classList.contains('is-active')
 	);


### PR DESCRIPTION
## Summary
- Exit early in `setupFade` when running inside the block editor
- Remove `is-active` classes in the block editor to keep all slides visible

## Testing
- `npm test` (fails: Missing script)
- `npx wp-scripts lint-js src/js/horizontal-fade.js`


------
https://chatgpt.com/codex/tasks/task_e_68ae00f544b8832b8ad0e435277762e7