### PR TITLE
Ensure group link type classes are properly removed

### DIFF
--- a/src/js/blocks/controls/group.js
+++ b/src/js/blocks/controls/group.js
@@ -50,11 +50,17 @@ export const controls = (BlockEdit, props) => (
 
 export const getClasses = (attributes) => {
 	let added = '';
+	const removed = [
+		'group-link-type-none',
+		'group-link-type-new_tab',
+		'group-link-type-modal_media',
+		'group-link-type-self',
+	];
 	if (attributes.enableGroupLink) {
 		const linkType = attributes.groupLinkType || 'self';
 		added += ` group-link group-link-type-${linkType}`;
 	}
-	return { added };
+	return { added, removed };
 };
 
 export default { controls, getClasses };


### PR DESCRIPTION
## Summary
- Add `removed` list with all `group-link-type-*` variants in group block controls
- Return `{ added, removed }` so stale link type classes are cleaned up

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint-js`


------
https://chatgpt.com/codex/tasks/task_e_68af02ae6e38832bb857dd7d1011932b