### PR TITLE
Refactor slider useHooks

### DIFF
--- a/src/js/blocks/controls/slider.js
+++ b/src/js/blocks/controls/slider.js
@@ -1,5 +1,4 @@
 /* eslint-disable @wordpress/no-unsafe-wp-apis */
-/* global MutationObserver */
 import { Fragment, useEffect } from '@wordpress/element';
 import { InspectorControls, URLInput } from '@wordpress/block-editor';
 import {
@@ -516,6 +515,9 @@ export const getClasses = (attributes) => {
 };
 
 export const useHooks = (props) => {
+	const { attributes, setAttributes, name } = props;
+	const { enableHorizontalScroller, isStackedOnMobile } = attributes;
+
 	useEffect(() => {
 		if (enableHorizontalScroller && isStackedOnMobile) {
 			setAttributes({ isStackedOnMobile: false });


### PR DESCRIPTION
## Summary
- destructure slider `useHooks` for cleaner variable usage
- remove unused `MutationObserver` global

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: vendor/bin/phpcs: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af0924888c832ba749c51e99c46a44