### PR TITLE
chore: clean up slider hooks

### DIFF
--- a/src/js/blocks/controls/slider.js
+++ b/src/js/blocks/controls/slider.js
@@ -515,7 +515,7 @@ export const getClasses = (attributes) => {
 };
 
 export const useHooks = (props) => {
-	const { attributes, setAttributes, name } = props;
+	const { attributes, setAttributes } = props;
 	const { enableHorizontalScroller, isStackedOnMobile } = attributes;
 
 	useEffect(() => {
@@ -523,8 +523,6 @@ export const useHooks = (props) => {
 			setAttributes({ isStackedOnMobile: false });
 		}
 	}, [enableHorizontalScroller, isStackedOnMobile, setAttributes]);
-
-	useEffect(() => {}, [name, enableHorizontalScroller]);
 };
 
 export default { controls, getClasses, useHooks };


### PR DESCRIPTION
## Summary
- ensure slider hook disables mobile stacking via proper dependencies
- drop unused effect from slider controls

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint-js`


------
https://chatgpt.com/codex/tasks/task_e_68af0aa8ba48832b87a3d035968524ea